### PR TITLE
Feature/anisotropic moc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -193,6 +193,7 @@ pybind11_add_module(_scarabee src/scarabee/_scarabee/logging.cpp
                               src/scarabee/_scarabee/pwr_assembly.cpp
                               src/scarabee/_scarabee/pwr_reflector.cpp
                               src/scarabee/_scarabee/reflector_sn.cpp
+                              src/scarabee/_scarabee/spherical_harmonics.cpp
                               #=================================================
                               src/scarabee/_scarabee/python/scarabee.cpp
                               src/scarabee/_scarabee/python/vector.cpp

--- a/examples/cylinder_anisotropic.py
+++ b/examples/cylinder_anisotropic.py
@@ -1,0 +1,87 @@
+# Analytical Benchmark Test Set for Criticality Code and Verification
+# Problem No.: 36 [Ua-1-1-CY]
+# Exact keff = 1.
+
+from scarabee import *
+import numpy as np
+import matplotlib.pyplot as plt
+
+
+Et = np.array([0.32640])
+Ea = np.array([0.32640-0.248064])
+Es = np.array([[[0.248064]],
+               [[0.042432]]])
+Ef = np.array([0.065280])
+vEf = np.array([2.70 * 0.065280])
+chi = np.array([1.])
+dtr = np.array([0.])
+fuel = CrossSection(Et, dtr, Ea, Es, Ef, vEf, chi)
+
+# fictitious material
+Ea = np.array([1E-4])
+Et = Ea
+Es = np.array([[[0.]],
+               [[0.]]])
+Ef = np.array([0.])
+vEf = np.array([0.])
+chi = np.array([0.])
+dtr = np.array([0.])
+fictitious_mat = CrossSection(Et, dtr, Ea, Es, Ef, vEf, chi)
+
+# Creating Cell
+
+# max length in x and y
+radius = 5.514296811
+length_x = 2 * radius
+length_y = 2 * radius
+# number of elements in x and y
+Nx = 200
+Ny = 200
+# delta x and y for element
+dx = length_x / Nx
+dy = length_y / Ny
+# low points
+x0 = -length_x * 0.5
+y0 = -length_y * 0.5
+
+# fuel-cell
+F = EmptyCell(fuel, dx, dy)
+# ficititious material cell
+N = EmptyCell(fictitious_mat, dx, dy)
+
+# creating the cylinder with small cubes
+c2d_dx = [dx] * Nx
+c2d_dy = [dy] * Ny
+
+root_univ = Cartesian2D(c2d_dx, c2d_dy)
+
+lattice = []
+for j in range(0, Ny):
+    # mid-y in the element
+    y = y0 + (j + 0.5) * dy
+
+    for i in range(0, Nx):
+        # mid-x in the element
+        x = x0 + (i + 0.5) * dx
+        # check, if the mid point is inside the cylinder
+        if (np.sqrt(x*x + y*y) < radius):
+            lattice.append(F)
+        else:
+            lattice.append(N)
+            
+root_univ.set_tiles(lattice)
+
+moc = MOCDriver(root_univ)
+moc.x_min_bc = BoundaryCondition.Vacuum
+moc.x_max_bc = BoundaryCondition.Vacuum
+moc.y_min_bc = BoundaryCondition.Vacuum
+moc.y_max_bc = BoundaryCondition.Vacuum
+moc.generate_tracks(128, 0.005, YamamotoTabuchi6())
+moc.flux_tolerance = 1.E-5
+
+# moc.plot()
+moc.solve()
+
+#flux, x, y = moc.rasterize_flux(100, 100)
+
+

--- a/examples/cylinder_anisotropic.py
+++ b/examples/cylinder_anisotropic.py
@@ -14,7 +14,7 @@ Es = np.array([[[0.248064]],
 Ef = np.array([0.065280])
 vEf = np.array([2.70 * 0.065280])
 chi = np.array([1.])
-dtr = np.array([0.])
+dtr = np.array([0.042432])
 fuel = CrossSection(Et, dtr, Ea, Es, Ef, vEf, chi)
 
 # fictitious material

--- a/examples/cylinder_anisotropic.py
+++ b/examples/cylinder_anisotropic.py
@@ -35,8 +35,8 @@ radius = 5.514296811
 length_x = 2 * radius
 length_y = 2 * radius
 # number of elements in x and y
-Nx = 200
-Ny = 200
+Nx = 100
+Ny = 100
 # delta x and y for element
 dx = length_x / Nx
 dy = length_y / Ny
@@ -71,12 +71,12 @@ for j in range(0, Ny):
             
 root_univ.set_tiles(lattice)
 
-moc = MOCDriver(root_univ)
+moc = MOCDriver(root_univ, anisotropic = True)
 moc.x_min_bc = BoundaryCondition.Vacuum
 moc.x_max_bc = BoundaryCondition.Vacuum
 moc.y_min_bc = BoundaryCondition.Vacuum
 moc.y_max_bc = BoundaryCondition.Vacuum
-moc.generate_tracks(128, 0.005, YamamotoTabuchi6())
+moc.generate_tracks(128, 0.01, YamamotoTabuchi6())
 moc.flux_tolerance = 1.E-5
 
 # moc.plot()

--- a/examples/slab_anisotropic.py
+++ b/examples/slab_anisotropic.py
@@ -29,11 +29,12 @@ slab = EmptyCell(fuel, dx, dy)
 fuel_slab = Cartesian2D(Nx*[dx], [dy])
 fuel_slab.set_tiles([slab] * Nx)
 
-moc = MOCDriver(fuel_slab)
+moc = MOCDriver(fuel_slab, anisotropic = True)
 moc.x_min_bc = BoundaryCondition.Vacuum
 moc.x_max_bc = BoundaryCondition.Vacuum
 moc.y_min_bc = BoundaryCondition.Reflective
 moc.y_max_bc = BoundaryCondition.Reflective
+
 moc.generate_tracks(128, 0.005, YamamotoTabuchi6())
 #moc.generate_tracks(128, 0.01, Legendre12())
 moc.flux_tolerance = 1.E-5

--- a/examples/slab_anisotropic.py
+++ b/examples/slab_anisotropic.py
@@ -14,7 +14,7 @@ Ef = np.array([0.266667])
 vEf = np.array([2.5 * 0.266667])
 chi = np.array([1.])
 
-dtr = np.array([0.])
+dtr = np.array([0.333333])
 
 fuel = CrossSection(Et, dtr, Ea, Es, Ef, vEf, chi)
 

--- a/examples/slab_anisotropic.py
+++ b/examples/slab_anisotropic.py
@@ -1,0 +1,46 @@
+# Analytical Benchmark Test Set for Criticality Code and Verification
+# Problem No.:32 [PUa-1-1-SL]
+# Exact keff = 1.
+
+from scarabee import *
+import numpy as np
+import matplotlib.pyplot as plt
+
+Et = np.array([1.])
+Ea = np.array([1. - 0.733333])
+Es = np.array([[[0.733333]],
+              [[0.333333]]])
+Ef = np.array([0.266667])
+vEf = np.array([2.5 * 0.266667])
+chi = np.array([1.])
+
+dtr = np.array([0.])
+
+fuel = CrossSection(Et, dtr, Ea, Es, Ef, vEf, chi)
+
+# Define Cells
+
+thickness =  0.79606 * 2.
+Nx = 500
+# slab
+dx = thickness / Nx
+dy = thickness
+slab = EmptyCell(fuel, dx, dy)
+fuel_slab = Cartesian2D(Nx*[dx], [dy])
+fuel_slab.set_tiles([slab] * Nx)
+
+moc = MOCDriver(fuel_slab)
+moc.x_min_bc = BoundaryCondition.Vacuum
+moc.x_max_bc = BoundaryCondition.Vacuum
+moc.y_min_bc = BoundaryCondition.Reflective
+moc.y_max_bc = BoundaryCondition.Reflective
+moc.generate_tracks(128, 0.005, YamamotoTabuchi6())
+#moc.generate_tracks(128, 0.01, Legendre12())
+moc.flux_tolerance = 1.E-5
+moc.keff_tolerance = 1.E-5
+
+moc.solve()
+
+flux, x, y = moc.rasterize_flux(1000, 1)
+plt.stairs(flux[0,0,:], edges=x)
+plt.show()

--- a/src/scarabee/_scarabee/include/moc/moc_driver.hpp
+++ b/src/scarabee/_scarabee/include/moc/moc_driver.hpp
@@ -114,13 +114,13 @@ class MOCDriver {
 
  private:
   struct AngleInfo {
-    double phi;        // Azimuthal angle for track
-    double d;          // Spacing for trackings of this angle
-    double wgt;        // Weight for tracks with this angle
-    std::uint32_t nx;  // Number of tracks starting on the -y boundary
-    std::uint32_t ny;  // Number of tracks starting on the -x boundary
-    std::size_t forward_index;  // azimuthal angle index in forward 
-    std::size_t backward_index; // azimuthal angle index in backward
+    double phi;                  // Azimuthal angle for track
+    double d;                    // Spacing for trackings of this angle
+    double wgt;                  // Weight for tracks with this angle
+    std::uint32_t nx;            // Number of tracks starting on the -y boundary
+    std::uint32_t ny;            // Number of tracks starting on the -x boundary
+    std::size_t forward_index;   // azimuthal angle index in forward
+    std::size_t backward_index;  // azimuthal angle index in backward
   };
 
   std::vector<AngleInfo> angle_info_;       // Information for all angles
@@ -135,9 +135,9 @@ class MOCDriver {
   std::size_t ngroups_;
   std::size_t nfsrs_;
   std::size_t n_pol_angles_;
-  std::size_t max_L_ = 0;   // max-legendre-order in scattering moments
-  std::size_t N_lj_ = 1; // total number of j (-l ro l)
-  bool anisotropic_ = false; // to account for anisotropic scattering
+  std::size_t max_L_ = 0;     // max-legendre-order in scattering moments
+  std::size_t N_lj_ = 1;      // total number of j (-l ro l)
+  bool anisotropic_ = false;  // to account for anisotropic scattering
   double flux_tol_ = 1.E-5;
   double keff_tol_ = 1.E-5;
   double keff_ = 1.;
@@ -159,14 +159,13 @@ class MOCDriver {
 
   // anisotropic
   void solve_anisotropic();
-  void sweep_anisotropic(xt::xtensor<double, 3>& flux, const xt::xtensor<double, 3>& src);
+  void sweep_anisotropic(xt::xtensor<double, 3>& flux,
+                         const xt::xtensor<double, 3>& src);
   void fill_source_anisotropic(xt::xtensor<double, 3>& src,
-                   const xt::xtensor<double, 3>& flux) const;
-
+                               const xt::xtensor<double, 3>& flux) const;
 
   double calc_keff(const xt::xtensor<double, 3>& flux,
                    const xt::xtensor<double, 3>& old_flux) const;
-  
 
   SphericalHarmonics sph_harm;
 };

--- a/src/scarabee/_scarabee/include/moc/moc_driver.hpp
+++ b/src/scarabee/_scarabee/include/moc/moc_driver.hpp
@@ -38,6 +38,8 @@ class MOCDriver {
 
   std::size_t ngroups() const { return ngroups_; }
 
+  std::size_t num_spherical_harmonics() const { return N_lj_; }
+
   double keff() const { return keff_; }
 
   SimulationMode& sim_mode() { return mode_; }

--- a/src/scarabee/_scarabee/include/moc/moc_driver.hpp
+++ b/src/scarabee/_scarabee/include/moc/moc_driver.hpp
@@ -8,6 +8,7 @@
 #include <moc/flat_source_region.hpp>
 #include <moc/track.hpp>
 #include <moc/quadrature/polar_quadrature.hpp>
+#include <utils/spherical_harmonics.hpp>
 
 #include <xtensor/xtensor.hpp>
 
@@ -125,7 +126,7 @@ class MOCDriver {
   std::shared_ptr<Cartesian2D> geometry_;   // Geometry for the problem
   std::shared_ptr<CMFD> cmfd_;              // CMFD for acceleration
   PolarQuadrature polar_quad_;              // Polar quadrature
-  xt::xtensor<double, 2> flux_;             // Indexed by group then FSR
+  xt::xtensor<double, 3> flux_;             // Indexed by group then FSR
   xt::xtensor<double, 2> extern_src_;       // Indexed by group then FSR
   std::vector<const FlatSourceRegion*> fsrs_;
   std::map<std::size_t, std::size_t> fsr_offsets_;  // Indexed by id -> offset
@@ -145,12 +146,14 @@ class MOCDriver {
   void allocate_track_fluxes();
   void segment_renormalization();
 
-  void sweep(xt::xtensor<double, 2>& flux, const xt::xtensor<double, 2>& src);
+  void sweep(xt::xtensor<double, 3>& flux, const xt::xtensor<double, 2>& src);
 
-  double calc_keff(const xt::xtensor<double, 2>& flux,
-                   const xt::xtensor<double, 2>& old_flux) const;
+  double calc_keff(const xt::xtensor<double, 3>& flux,
+                   const xt::xtensor<double, 3>& old_flux) const;
   void fill_source(xt::xtensor<double, 2>& src,
-                   const xt::xtensor<double, 2>& flux) const;
+                   const xt::xtensor<double, 3>& flux) const;
+
+  SphericalHarmonics sph_harm;
 };
 
 }  // namespace scarabee

--- a/src/scarabee/_scarabee/include/moc/moc_driver.hpp
+++ b/src/scarabee/_scarabee/include/moc/moc_driver.hpp
@@ -119,6 +119,8 @@ class MOCDriver {
     double wgt;        // Weight for tracks with this angle
     std::uint32_t nx;  // Number of tracks starting on the -y boundary
     std::uint32_t ny;  // Number of tracks starting on the -x boundary
+    std::size_t forward_index;  // azimuthal angle index in forward 
+    std::size_t backward_index; // azimuthal angle index in backward
   };
 
   std::vector<AngleInfo> angle_info_;       // Information for all angles
@@ -133,6 +135,9 @@ class MOCDriver {
   std::size_t ngroups_;
   std::size_t nfsrs_;
   std::size_t n_pol_angles_;
+  std::size_t max_L_ = 0;   // max-legendre-order in scattering moments
+  std::size_t N_lj_ = 1; // total number of j (-l ro l)
+  bool anisotropic_ = false; // to account for anisotropic scattering
   double flux_tol_ = 1.E-5;
   double keff_tol_ = 1.E-5;
   double keff_ = 1.;
@@ -146,6 +151,8 @@ class MOCDriver {
   void allocate_track_fluxes();
   void segment_renormalization();
 
+  // isotropic
+  void solve_isotropic();
   void sweep(xt::xtensor<double, 3>& flux, const xt::xtensor<double, 2>& src);
 
   double calc_keff(const xt::xtensor<double, 3>& flux,

--- a/src/scarabee/_scarabee/include/moc/moc_driver.hpp
+++ b/src/scarabee/_scarabee/include/moc/moc_driver.hpp
@@ -24,7 +24,8 @@ class MOCDriver {
             BoundaryCondition xmin = BoundaryCondition::Reflective,
             BoundaryCondition xmax = BoundaryCondition::Reflective,
             BoundaryCondition ymin = BoundaryCondition::Reflective,
-            BoundaryCondition ymax = BoundaryCondition::Reflective);
+            BoundaryCondition ymax = BoundaryCondition::Reflective,
+            bool anisotropic = false);
 
   std::shared_ptr<Cartesian2D> geometry() const { return geometry_; }
 
@@ -128,6 +129,7 @@ class MOCDriver {
   std::shared_ptr<Cartesian2D> geometry_;   // Geometry for the problem
   std::shared_ptr<CMFD> cmfd_;              // CMFD for acceleration
   PolarQuadrature polar_quad_;              // Polar quadrature
+  SphericalHarmonics sph_harm_;              // Spherical harmonics
   xt::xtensor<double, 3> flux_;             // Indexed by group then FSR
   xt::xtensor<double, 2> extern_src_;       // Indexed by group then FSR
   std::vector<const FlatSourceRegion*> fsrs_;
@@ -135,13 +137,13 @@ class MOCDriver {
   std::size_t ngroups_;
   std::size_t nfsrs_;
   std::size_t n_pol_angles_;
-  std::size_t max_L_ = 0;     // max-legendre-order in scattering moments
-  std::size_t N_lj_ = 1;      // total number of j (-l ro l)
-  bool anisotropic_ = false;  // to account for anisotropic scattering
   double flux_tol_ = 1.E-5;
   double keff_tol_ = 1.E-5;
   double keff_ = 1.;
   BoundaryCondition x_min_bc_, x_max_bc_, y_min_bc_, y_max_bc_;
+  std::size_t max_L_ = 0;     // max-legendre-order in scattering moments
+  std::size_t N_lj_ = 1;      // total number of j (-l ro l)
+  bool anisotropic_ = false;  // to account for anisotropic scattering
   SimulationMode mode_{SimulationMode::Keff};
   bool solved_{false};
 
@@ -166,8 +168,6 @@ class MOCDriver {
 
   double calc_keff(const xt::xtensor<double, 3>& flux,
                    const xt::xtensor<double, 3>& old_flux) const;
-
-  SphericalHarmonics sph_harm;
 };
 
 }  // namespace scarabee

--- a/src/scarabee/_scarabee/include/moc/moc_driver.hpp
+++ b/src/scarabee/_scarabee/include/moc/moc_driver.hpp
@@ -72,8 +72,8 @@ class MOCDriver {
   std::size_t nregions() const { return this->nfsr(); }
 
   double flux(const Vector& r, const Direction& u, std::size_t g,
-              std::size_t lg = 0) const;
-  double flux(std::size_t i, std::size_t g, std::size_t lg = 0) const;
+              std::size_t lj = 0) const;
+  double flux(std::size_t i, std::size_t g, std::size_t lj = 0) const;
 
   double volume(const Vector& r, const Direction& u) const;
   double volume(std::size_t i) const;

--- a/src/scarabee/_scarabee/include/moc/moc_driver.hpp
+++ b/src/scarabee/_scarabee/include/moc/moc_driver.hpp
@@ -69,8 +69,9 @@ class MOCDriver {
   std::size_t nfsr() const { return this->size(); }
   std::size_t nregions() const { return this->nfsr(); }
 
-  double flux(const Vector& r, const Direction& u, std::size_t g) const;
-  double flux(std::size_t i, std::size_t g) const;
+  double flux(const Vector& r, const Direction& u, std::size_t g,
+              std::size_t lg = 0) const;
+  double flux(std::size_t i, std::size_t g, std::size_t lg = 0) const;
 
   double volume(const Vector& r, const Direction& u) const;
   double volume(std::size_t i) const;
@@ -129,9 +130,10 @@ class MOCDriver {
   std::shared_ptr<Cartesian2D> geometry_;   // Geometry for the problem
   std::shared_ptr<CMFD> cmfd_;              // CMFD for acceleration
   PolarQuadrature polar_quad_;              // Polar quadrature
-  SphericalHarmonics sph_harm_;              // Spherical harmonics
-  xt::xtensor<double, 3> flux_;             // Indexed by group then FSR
-  xt::xtensor<double, 2> extern_src_;       // Indexed by group then FSR
+  SphericalHarmonics sph_harm_;             // Spherical harmonics
+  xt::xtensor<double, 3>
+      flux_;  // Indexed by group, FSR, and spherical harmonic
+  xt::xtensor<double, 2> extern_src_;  // Indexed by group then FSR
   std::vector<const FlatSourceRegion*> fsrs_;
   std::map<std::size_t, std::size_t> fsr_offsets_;  // Indexed by id -> offset
   std::size_t ngroups_;

--- a/src/scarabee/_scarabee/include/moc/moc_driver.hpp
+++ b/src/scarabee/_scarabee/include/moc/moc_driver.hpp
@@ -154,11 +154,19 @@ class MOCDriver {
   // isotropic
   void solve_isotropic();
   void sweep(xt::xtensor<double, 3>& flux, const xt::xtensor<double, 2>& src);
+  void fill_source(xt::xtensor<double, 2>& src,
+                   const xt::xtensor<double, 3>& flux) const;
+
+  // anisotropic
+  void solve_anisotropic();
+  void sweep_anisotropic(xt::xtensor<double, 3>& flux, const xt::xtensor<double, 3>& src);
+  void fill_source_anisotropic(xt::xtensor<double, 3>& src,
+                   const xt::xtensor<double, 3>& flux) const;
+
 
   double calc_keff(const xt::xtensor<double, 3>& flux,
                    const xt::xtensor<double, 3>& old_flux) const;
-  void fill_source(xt::xtensor<double, 2>& src,
-                   const xt::xtensor<double, 3>& flux) const;
+  
 
   SphericalHarmonics sph_harm;
 };

--- a/src/scarabee/_scarabee/include/moc/quadrature/legendre.hpp
+++ b/src/scarabee/_scarabee/include/moc/quadrature/legendre.hpp
@@ -21,7 +21,9 @@ class Legendre {
 
   std::span<const double> wsin() const { return {wsin_.begin(), wsin_.end()}; }
 
-  std::span<const double> polar_angle() const { return {polar_angle_.begin(), polar_angle_.end()}; }
+  std::span<const double> polar_angle() const {
+    return {polar_angle_.begin(), polar_angle_.end()};
+  }
 
  private:
   static const std::array<double, N / 2> invs_sin_;

--- a/src/scarabee/_scarabee/include/moc/quadrature/legendre.hpp
+++ b/src/scarabee/_scarabee/include/moc/quadrature/legendre.hpp
@@ -21,11 +21,14 @@ class Legendre {
 
   std::span<const double> wsin() const { return {wsin_.begin(), wsin_.end()}; }
 
+  std::span<const double> polar_angle() const { return {polar_angle_.begin(), polar_angle_.end()}; }
+
  private:
   static const std::array<double, N / 2> invs_sin_;
   static const std::array<double, N / 2> wsin_;
   static const std::array<double, N / 2> sin_;
   static const std::array<double, N / 2> wgt_;
+  static const std::array<double, N / 2> polar_angle_;
 };
 
 }  // namespace scarabee

--- a/src/scarabee/_scarabee/include/moc/quadrature/polar_quadrature.hpp
+++ b/src/scarabee/_scarabee/include/moc/quadrature/polar_quadrature.hpp
@@ -22,6 +22,7 @@ class PolarQuadrature {
     wsin_ = std::visit([](const auto& pq) { return pq.wsin(); }, pq_);
     sin_ = std::visit([](const auto& pq) { return pq.sin(); }, pq_);
     wgt_ = std::visit([](const auto& pq) { return pq.wgt(); }, pq_);
+    polar_angle_ = std::visit([](const auto& pq) { return pq.polar_angle(); }, pq_);
   }
 
   PolarQuadrature(PolarQuadratureType pq)
@@ -30,12 +31,14 @@ class PolarQuadrature {
     wsin_ = std::visit([](const auto& pq) { return pq.wsin(); }, pq_);
     sin_ = std::visit([](const auto& pq) { return pq.sin(); }, pq_);
     wgt_ = std::visit([](const auto& pq) { return pq.wgt(); }, pq_);
+    polar_angle_ = std::visit([](const auto& pq) { return pq.polar_angle(); }, pq_);
   }
 
   const std::span<const double>& invs_sin() const { return invs_sin_; }
   const std::span<const double>& wsin() const { return wsin_; }
   const std::span<const double>& sin() const { return sin_; }
   const std::span<const double>& wgt() const { return wgt_; }
+  const std::span<const double>& polar_angle() const { return polar_angle_; }
 
  private:
   PolarQuadratureType pq_;
@@ -43,6 +46,7 @@ class PolarQuadrature {
   std::span<const double> wsin_;
   std::span<const double> sin_;
   std::span<const double> wgt_;
+  std::span<const double> polar_angle_;
 };
 
 }  // namespace scarabee

--- a/src/scarabee/_scarabee/include/moc/quadrature/polar_quadrature.hpp
+++ b/src/scarabee/_scarabee/include/moc/quadrature/polar_quadrature.hpp
@@ -22,7 +22,8 @@ class PolarQuadrature {
     wsin_ = std::visit([](const auto& pq) { return pq.wsin(); }, pq_);
     sin_ = std::visit([](const auto& pq) { return pq.sin(); }, pq_);
     wgt_ = std::visit([](const auto& pq) { return pq.wgt(); }, pq_);
-    polar_angle_ = std::visit([](const auto& pq) { return pq.polar_angle(); }, pq_);
+    polar_angle_ =
+        std::visit([](const auto& pq) { return pq.polar_angle(); }, pq_);
   }
 
   PolarQuadrature(PolarQuadratureType pq)
@@ -31,7 +32,8 @@ class PolarQuadrature {
     wsin_ = std::visit([](const auto& pq) { return pq.wsin(); }, pq_);
     sin_ = std::visit([](const auto& pq) { return pq.sin(); }, pq_);
     wgt_ = std::visit([](const auto& pq) { return pq.wgt(); }, pq_);
-    polar_angle_ = std::visit([](const auto& pq) { return pq.polar_angle(); }, pq_);
+    polar_angle_ =
+        std::visit([](const auto& pq) { return pq.polar_angle(); }, pq_);
   }
 
   const std::span<const double>& invs_sin() const { return invs_sin_; }

--- a/src/scarabee/_scarabee/include/moc/quadrature/yamamoto_tabuchi.hpp
+++ b/src/scarabee/_scarabee/include/moc/quadrature/yamamoto_tabuchi.hpp
@@ -26,7 +26,9 @@ class YamamotoTabuchi {
 
   std::span<const double> wsin() const { return {wsin_.begin(), wsin_.end()}; }
 
-  std::span<const double> polar_angle() const { return {polar_angle_.begin(), polar_angle_.end()}; }
+  std::span<const double> polar_angle() const {
+    return {polar_angle_.begin(), polar_angle_.end()};
+  }
 
  private:
   static const std::array<double, N / 2> invs_sin_;

--- a/src/scarabee/_scarabee/include/moc/quadrature/yamamoto_tabuchi.hpp
+++ b/src/scarabee/_scarabee/include/moc/quadrature/yamamoto_tabuchi.hpp
@@ -26,11 +26,14 @@ class YamamotoTabuchi {
 
   std::span<const double> wsin() const { return {wsin_.begin(), wsin_.end()}; }
 
+  std::span<const double> polar_angle() const { return {polar_angle_.begin(), polar_angle_.end()}; }
+
  private:
   static const std::array<double, N / 2> invs_sin_;
   static const std::array<double, N / 2> wsin_;
   static const std::array<double, N / 2> sin_;
   static const std::array<double, N / 2> wgt_;
+  static const std::array<double, N / 2> polar_angle_;
 };
 
 }  // namespace scarabee

--- a/src/scarabee/_scarabee/include/moc/track.hpp
+++ b/src/scarabee/_scarabee/include/moc/track.hpp
@@ -17,12 +17,15 @@ class Track {
  public:
   Track(const Vector& entry, const Vector& exit, const Direction& dir,
         double phi, double wgt, double width,
-        const std::vector<Segment>& segments);
+        const std::vector<Segment>& segments, std::size_t forward_phi_index,
+        std::size_t backward_phi_index);
 
   double wgt() const { return wgt_; }
   double width() const { return width_; }
   double phi() const { return phi_; }
   const std::vector<Segment>& segments() const { return segments_; }
+  std::size_t phi_index_forward() const { return forward_phi_index_; }
+  std::size_t phi_index_backward() const { return backward_phi_index_; }
 
   const Vector& entry_pos() const { return entry_; }
   const Vector& exit_pos() const { return exit_; }
@@ -96,6 +99,9 @@ class Track {
   double phi_;    // Azimuthal angle of Track
   BoundaryCondition entry_bc_;
   BoundaryCondition exit_bc_;
+  std::size_t forward_phi_index_;  // azimuthal angle index in forward direction
+  std::size_t
+      backward_phi_index_;  // azimuthal angle index in backaward direction
 };
 
 }  // namespace scarabee

--- a/src/scarabee/_scarabee/include/utils/math.hpp
+++ b/src/scarabee/_scarabee/include/utils/math.hpp
@@ -49,17 +49,15 @@ inline double mexp(double x) {
 double Ki3(double x);
 double Ki3_quad(double x);
 
-double legendre(const unsigned int& order, const double& x);
-double derivative_legendre(const unsigned int& order, const unsigned int& n,
-                           const double& x);
-double assoc_legendre(const unsigned int& order, const int& j, const double& x);
+double legendre(unsigned int order, double x);
+double derivative_legendre(unsigned int order, unsigned int n, double x);
+double assoc_legendre(unsigned int order, int j, double x);
 
 // // spherical harmonics
 // // phi: azimuthal angle and theta: polar angle
-double spherical_hamonics(const unsigned int& l, const int& j,
-                          const double& phi, const double& theta);
+double spherical_hamonics(unsigned int l, int j, double phi, double theta);
 
-inline double factorial(const unsigned int& N) {
+inline double factorial(unsigned int N) {
   double value = 1.;
   for (unsigned int i = 1; i <= N; i++) {
     value *= static_cast<double>(i);

--- a/src/scarabee/_scarabee/include/utils/math.hpp
+++ b/src/scarabee/_scarabee/include/utils/math.hpp
@@ -49,6 +49,24 @@ inline double mexp(double x) {
 double Ki3(double x);
 double Ki3_quad(double x);
 
+double legendre(const unsigned int& order, const double& x);
+double derivative_legendre(const unsigned int& order, const unsigned int& n,
+                           const double& x);
+double assoc_legendre(const unsigned int& order, const int& j, const double& x);
+
+// // spherical harmonics
+// // phi: azimuthal angle and theta: polar angle
+double spherical_hamonics(const unsigned int& l, const int& j,
+                          const double& phi, const double& theta);
+
+inline double factorial(const unsigned int& N) {
+  double value = 1.;
+  for (unsigned int i = 1; i <= N; i++) {
+    value *= static_cast<double>(i);
+  }
+  return value;
+}
+
 }  // namespace scarabee
 
 #endif

--- a/src/scarabee/_scarabee/include/utils/spherical_harmonics.hpp
+++ b/src/scarabee/_scarabee/include/utils/spherical_harmonics.hpp
@@ -1,0 +1,63 @@
+#ifndef SPHERICAL_HARMONICS_V2_H
+#define SPHERICAL_HARMONICS_V2_H
+
+#include <utils/constants.hpp>
+
+#include <cstdint>
+#include <span>
+
+#include <xtensor/xtensor.hpp>
+#include <xtensor/xview.hpp>
+
+namespace scarabee {
+
+class SphericalHarmonics{
+    public:
+        SphericalHarmonics() = default;
+
+        SphericalHarmonics(const std::size_t& L, const std::vector<double>& azimuthal_angle, const std::vector<double>& polar_angle);
+
+        std::span<const double> spherical_harmonics(const std::size_t phi_index, const std::size_t theta_index) const {
+            std::span<const double> Ylj(&all_harmonics_(phi_index, theta_index, 0), Nlj_);
+            return Ylj;
+        }
+
+    private:
+        xt::xtensor<double, 3> all_harmonics_; // Phi (azimuthal angle), Theta (polar angle), l/j spherical harmonics
+        std::size_t L_;
+        std::size_t Nlj_;
+
+        // general method to evaluate the spherical harmonics
+        double eval_spherical_harmonics(const std::size_t& l, const int& j, const double& theta, const double& phi) const;
+
+
+        // factorial
+        double factorial(const std::size_t& N) const {
+            if (N == 1 || N == 0)
+                return 1.;
+            else
+                return static_cast<double>(N) * factorial(N-1);
+        }
+        
+        // method of evaluae the legendre
+        double eval_legendre(const std::size_t& order, const double& x) const {
+            if (order > 1){
+                return (static_cast<double>(2*order - 1)*eval_legendre(order-1, x) * x - static_cast<double>(order-1) * eval_legendre(order-2, x)) / static_cast<double>(order);
+            }else if (order == 1){
+                return x;
+            }
+
+            // if order == 0
+            return 1.;
+        }
+
+        // method to get differentiation of legendre-polynomial
+        double eval_legendre_differentiation(const std::size_t& order, const std::size_t& n, const double& x) const;
+        // method to get the associated legendre
+        double eval_associated_legendre(const std::size_t& order, const int& j, const double& x) const;
+    
+};
+
+} // namespace scarabee
+
+#endif

--- a/src/scarabee/_scarabee/include/utils/spherical_harmonics.hpp
+++ b/src/scarabee/_scarabee/include/utils/spherical_harmonics.hpp
@@ -1,5 +1,5 @@
-#ifndef SPHERICAL_HARMONICS_V2_H
-#define SPHERICAL_HARMONICS_V2_H
+#ifndef SPHERICAL_HARMONICS_H
+#define SPHERICAL_HARMONICS_H
 
 #include <cstdint>
 #include <span>
@@ -29,41 +29,6 @@ class SphericalHarmonics {
                                           // angle), l/j spherical harmonics
   std::size_t L_;
   std::size_t Nlj_;
-
-  // general method to evaluate the spherical harmonics
-  double eval_spherical_harmonics(const std::size_t& l, const int& j,
-                                  const double& theta, const double& phi) const;
-
-  // factorial
-  double factorial(const std::size_t& N) const {
-    if (N == 1 || N == 0)
-      return 1.;
-    else
-      return static_cast<double>(N) * factorial(N - 1);
-  }
-
-  // method of evaluae the legendre
-  double eval_legendre(const std::size_t& order, const double& x) const {
-    if (order > 1) {
-      return (static_cast<double>(2 * order - 1) * eval_legendre(order - 1, x) *
-                  x -
-              static_cast<double>(order - 1) * eval_legendre(order - 2, x)) /
-             static_cast<double>(order);
-    } else if (order == 1) {
-      return x;
-    }
-
-    // if order == 0
-    return 1.;
-  }
-
-  // method to get differentiation of legendre-polynomial
-  double eval_legendre_differentiation(const std::size_t& order,
-                                       const std::size_t& n,
-                                       const double& x) const;
-  // method to get the associated legendre
-  double eval_associated_legendre(const std::size_t& order, const int& j,
-                                  const double& x) const;
 };
 
 }  // namespace scarabee

--- a/src/scarabee/_scarabee/include/utils/spherical_harmonics.hpp
+++ b/src/scarabee/_scarabee/include/utils/spherical_harmonics.hpp
@@ -11,53 +11,63 @@
 
 namespace scarabee {
 
-class SphericalHarmonics{
-    public:
-        SphericalHarmonics() = default;
+class SphericalHarmonics {
+ public:
+  SphericalHarmonics() = default;
 
-        SphericalHarmonics(const std::size_t& L, const std::vector<double>& azimuthal_angle, const std::vector<double>& polar_angle);
+  SphericalHarmonics(const std::size_t& L,
+                     const std::vector<double>& azimuthal_angle,
+                     const std::vector<double>& polar_angle);
 
-        std::span<const double> spherical_harmonics(const std::size_t phi_index, const std::size_t theta_index) const {
-            std::span<const double> Ylj(&all_harmonics_(phi_index, theta_index, 0), Nlj_);
-            return Ylj;
-        }
+  std::span<const double> spherical_harmonics(
+      const std::size_t phi_index, const std::size_t theta_index) const {
+    std::span<const double> Ylj(&all_harmonics_(phi_index, theta_index, 0),
+                                Nlj_);
+    return Ylj;
+  }
 
-    private:
-        xt::xtensor<double, 3> all_harmonics_; // Phi (azimuthal angle), Theta (polar angle), l/j spherical harmonics
-        std::size_t L_;
-        std::size_t Nlj_;
+ private:
+  xt::xtensor<double, 3> all_harmonics_;  // Phi (azimuthal angle), Theta (polar
+                                          // angle), l/j spherical harmonics
+  std::size_t L_;
+  std::size_t Nlj_;
 
-        // general method to evaluate the spherical harmonics
-        double eval_spherical_harmonics(const std::size_t& l, const int& j, const double& theta, const double& phi) const;
+  // general method to evaluate the spherical harmonics
+  double eval_spherical_harmonics(const std::size_t& l, const int& j,
+                                  const double& theta, const double& phi) const;
 
+  // factorial
+  double factorial(const std::size_t& N) const {
+    if (N == 1 || N == 0)
+      return 1.;
+    else
+      return static_cast<double>(N) * factorial(N - 1);
+  }
 
-        // factorial
-        double factorial(const std::size_t& N) const {
-            if (N == 1 || N == 0)
-                return 1.;
-            else
-                return static_cast<double>(N) * factorial(N-1);
-        }
-        
-        // method of evaluae the legendre
-        double eval_legendre(const std::size_t& order, const double& x) const {
-            if (order > 1){
-                return (static_cast<double>(2*order - 1)*eval_legendre(order-1, x) * x - static_cast<double>(order-1) * eval_legendre(order-2, x)) / static_cast<double>(order);
-            }else if (order == 1){
-                return x;
-            }
+  // method of evaluae the legendre
+  double eval_legendre(const std::size_t& order, const double& x) const {
+    if (order > 1) {
+      return (static_cast<double>(2 * order - 1) * eval_legendre(order - 1, x) *
+                  x -
+              static_cast<double>(order - 1) * eval_legendre(order - 2, x)) /
+             static_cast<double>(order);
+    } else if (order == 1) {
+      return x;
+    }
 
-            // if order == 0
-            return 1.;
-        }
+    // if order == 0
+    return 1.;
+  }
 
-        // method to get differentiation of legendre-polynomial
-        double eval_legendre_differentiation(const std::size_t& order, const std::size_t& n, const double& x) const;
-        // method to get the associated legendre
-        double eval_associated_legendre(const std::size_t& order, const int& j, const double& x) const;
-    
+  // method to get differentiation of legendre-polynomial
+  double eval_legendre_differentiation(const std::size_t& order,
+                                       const std::size_t& n,
+                                       const double& x) const;
+  // method to get the associated legendre
+  double eval_associated_legendre(const std::size_t& order, const int& j,
+                                  const double& x) const;
 };
 
-} // namespace scarabee
+}  // namespace scarabee
 
 #endif

--- a/src/scarabee/_scarabee/include/utils/spherical_harmonics.hpp
+++ b/src/scarabee/_scarabee/include/utils/spherical_harmonics.hpp
@@ -1,8 +1,6 @@
 #ifndef SPHERICAL_HARMONICS_V2_H
 #define SPHERICAL_HARMONICS_V2_H
 
-#include <utils/constants.hpp>
-
 #include <cstdint>
 #include <span>
 

--- a/src/scarabee/_scarabee/legendre.cpp
+++ b/src/scarabee/_scarabee/legendre.cpp
@@ -15,6 +15,8 @@ const std::array<double, 1> Legendre<2>::wgt_ = {
     1.00000000000000000000000000000000000e+00};
 template <>
 const std::array<double, 1> Legendre<2>::wsin_ = {wgt_[0] * sin_[0]};
+template <>
+const std::array<double, 1> Legendre<2>::polar_angle_ = {std::asin(sin_[0])};
 
 // N = 4
 template <>
@@ -31,6 +33,8 @@ const std::array<double, 2> Legendre<4>::wgt_ = {
 template <>
 const std::array<double, 2> Legendre<4>::wsin_ = {wgt_[0] * sin_[0],
                                                   wgt_[1] * sin_[1]};
+template <>
+const std::array<double, 2> Legendre<4>::polar_angle_ = {std::asin(sin_[0]), std::asin(sin_[1])};
 
 // N = 6
 template <>
@@ -49,6 +53,8 @@ const std::array<double, 3> Legendre<6>::wgt_ = {
 template <>
 const std::array<double, 3> Legendre<6>::wsin_ = {
     wgt_[0] * sin_[0], wgt_[1] * sin_[1], wgt_[2] * sin_[2]};
+template <>
+const std::array<double, 3> Legendre<6>::polar_angle_ = {std::asin(sin_[0]), std::asin(sin_[1]), std::asin(sin_[2])};
 
 // N = 8
 template <>
@@ -69,6 +75,8 @@ const std::array<double, 4> Legendre<8>::wgt_ = {
 template <>
 const std::array<double, 4> Legendre<8>::wsin_ = {
     wgt_[0] * sin_[0], wgt_[1] * sin_[1], wgt_[2] * sin_[2], wgt_[3] * sin_[3]};
+template <>
+const std::array<double, 4> Legendre<8>::polar_angle_ = {std::asin(sin_[0]), std::asin(sin_[1]), std::asin(sin_[2]), std::asin(sin_[3])};
 
 // N = 10
 template <>
@@ -92,6 +100,8 @@ template <>
 const std::array<double, 5> Legendre<10>::wsin_ = {
     wgt_[0] * sin_[0], wgt_[1] * sin_[1], wgt_[2] * sin_[2], wgt_[3] * sin_[3],
     wgt_[4] * sin_[4]};
+template <>
+const std::array<double, 5> Legendre<10>::polar_angle_ = {std::asin(sin_[0]), std::asin(sin_[1]), std::asin(sin_[2]), std::asin(sin_[3]), std::asin(sin_[4])};
 
 // N = 12
 template <>
@@ -118,5 +128,7 @@ template <>
 const std::array<double, 6> Legendre<12>::wsin_ = {
     wgt_[0] * sin_[0], wgt_[1] * sin_[1], wgt_[2] * sin_[2],
     wgt_[3] * sin_[3], wgt_[4] * sin_[4], wgt_[5] * sin_[5]};
+template <>
+const std::array<double, 6> Legendre<12>::polar_angle_ = {std::asin(sin_[0]), std::asin(sin_[1]), std::asin(sin_[2]), std::asin(sin_[3]), std::asin(sin_[4]), std::asin(sin_[5])};
 
 }  // namespace scarabee

--- a/src/scarabee/_scarabee/legendre.cpp
+++ b/src/scarabee/_scarabee/legendre.cpp
@@ -34,7 +34,8 @@ template <>
 const std::array<double, 2> Legendre<4>::wsin_ = {wgt_[0] * sin_[0],
                                                   wgt_[1] * sin_[1]};
 template <>
-const std::array<double, 2> Legendre<4>::polar_angle_ = {std::asin(sin_[0]), std::asin(sin_[1])};
+const std::array<double, 2> Legendre<4>::polar_angle_ = {std::asin(sin_[0]),
+                                                         std::asin(sin_[1])};
 
 // N = 6
 template <>
@@ -54,7 +55,8 @@ template <>
 const std::array<double, 3> Legendre<6>::wsin_ = {
     wgt_[0] * sin_[0], wgt_[1] * sin_[1], wgt_[2] * sin_[2]};
 template <>
-const std::array<double, 3> Legendre<6>::polar_angle_ = {std::asin(sin_[0]), std::asin(sin_[1]), std::asin(sin_[2])};
+const std::array<double, 3> Legendre<6>::polar_angle_ = {
+    std::asin(sin_[0]), std::asin(sin_[1]), std::asin(sin_[2])};
 
 // N = 8
 template <>
@@ -76,7 +78,9 @@ template <>
 const std::array<double, 4> Legendre<8>::wsin_ = {
     wgt_[0] * sin_[0], wgt_[1] * sin_[1], wgt_[2] * sin_[2], wgt_[3] * sin_[3]};
 template <>
-const std::array<double, 4> Legendre<8>::polar_angle_ = {std::asin(sin_[0]), std::asin(sin_[1]), std::asin(sin_[2]), std::asin(sin_[3])};
+const std::array<double, 4> Legendre<8>::polar_angle_ = {
+    std::asin(sin_[0]), std::asin(sin_[1]), std::asin(sin_[2]),
+    std::asin(sin_[3])};
 
 // N = 10
 template <>
@@ -101,7 +105,9 @@ const std::array<double, 5> Legendre<10>::wsin_ = {
     wgt_[0] * sin_[0], wgt_[1] * sin_[1], wgt_[2] * sin_[2], wgt_[3] * sin_[3],
     wgt_[4] * sin_[4]};
 template <>
-const std::array<double, 5> Legendre<10>::polar_angle_ = {std::asin(sin_[0]), std::asin(sin_[1]), std::asin(sin_[2]), std::asin(sin_[3]), std::asin(sin_[4])};
+const std::array<double, 5> Legendre<10>::polar_angle_ = {
+    std::asin(sin_[0]), std::asin(sin_[1]), std::asin(sin_[2]),
+    std::asin(sin_[3]), std::asin(sin_[4])};
 
 // N = 12
 template <>
@@ -129,6 +135,8 @@ const std::array<double, 6> Legendre<12>::wsin_ = {
     wgt_[0] * sin_[0], wgt_[1] * sin_[1], wgt_[2] * sin_[2],
     wgt_[3] * sin_[3], wgt_[4] * sin_[4], wgt_[5] * sin_[5]};
 template <>
-const std::array<double, 6> Legendre<12>::polar_angle_ = {std::asin(sin_[0]), std::asin(sin_[1]), std::asin(sin_[2]), std::asin(sin_[3]), std::asin(sin_[4]), std::asin(sin_[5])};
+const std::array<double, 6> Legendre<12>::polar_angle_ = {
+    std::asin(sin_[0]), std::asin(sin_[1]), std::asin(sin_[2]),
+    std::asin(sin_[3]), std::asin(sin_[4]), std::asin(sin_[5])};
 
 }  // namespace scarabee

--- a/src/scarabee/_scarabee/math.cpp
+++ b/src/scarabee/_scarabee/math.cpp
@@ -162,7 +162,7 @@ double Ki3_quad(double x) {
   return integral.first;
 }
 
-double legendre(const unsigned int& order, const double& x) {
+double legendre(unsigned int order, double x) {
   switch (order) {
     case 0:
       return 1.0;
@@ -221,8 +221,7 @@ double legendre(const unsigned int& order, const double& x) {
   }
 }
 
-double derivative_legendre(const unsigned int& order, const unsigned int& n,
-                           const double& x) {
+double derivative_legendre(unsigned int order, unsigned int n, double x) {
   if (n > 0) {
     if (order > 1) {  // a recursion relation for order > 1 and n > 0
       const double term1 = derivative_legendre(order - 1, n, x) * x;
@@ -243,8 +242,7 @@ double derivative_legendre(const unsigned int& order, const unsigned int& n,
   return 0.;
 }
 
-double assoc_legendre(const unsigned int& order, const int& j,
-                      const double& x) {
+double assoc_legendre(unsigned int order, int j, double x) {
   unsigned int abs_j = std::abs(j);
   const double associated_l = derivative_legendre(order, abs_j, x);
   double factor = std::pow(-1., abs_j) *
@@ -257,8 +255,7 @@ double assoc_legendre(const unsigned int& order, const int& j,
   return factor * associated_l;
 }
 
-double spherical_hamonics(const unsigned int& l, const int& j,
-                          const double& phi, const double& theta) {
+double spherical_hamonics(unsigned int l, int j, double phi, double theta) {
   // theta is the polar angle, get the cosine of it.
   const double u = std::cos(theta);
   if (std::abs(j) > l) {

--- a/src/scarabee/_scarabee/moc_driver.cpp
+++ b/src/scarabee/_scarabee/moc_driver.cpp
@@ -84,12 +84,10 @@ MOCDriver::MOCDriver(std::shared_ptr<Cartesian2D> geometry,
   // get the max-legendre-order for given scattering moments
   if (anisotropic_) {
     max_L_ = 0;
-    if (anisotropic_ == true) {
-      for (std::size_t i = 0; i < nfsrs_; i++) {
-        const auto& mat = *fsrs_[i]->xs();
-        const std::size_t l = mat.max_legendre_order();
-        if (l > max_L_) max_L_ = l;
-      }
+    for (std::size_t i = 0; i < nfsrs_; i++) {
+      const auto& mat = *fsrs_[i]->xs();
+      const std::size_t l = mat.max_legendre_order();
+      if (l > max_L_) max_L_ = l;
     }
 
     N_lj_ = (max_L_ + 1) * (max_L_ + 1);
@@ -732,7 +730,7 @@ void MOCDriver::sweep_anisotropic(xt::xtensor<double, 3>& sflux,
     for (std::size_t i = 0; i < nfsrs_; i++) {
       const auto& mat = *fsrs_[i]->xs();
       const double Vi = fsrs_[i]->volume();
-      const double Et = mat.Etr(g);
+      const double Et = mat.Et(g);
       for (std::size_t it_lj = 0; it_lj < N_lj_; it_lj++) {
         sflux(g, i, it_lj) *= 1. / (Vi * Et);
       }

--- a/src/scarabee/_scarabee/moc_driver.cpp
+++ b/src/scarabee/_scarabee/moc_driver.cpp
@@ -423,6 +423,7 @@ void MOCDriver::solve_anisotropic() {
     iteration++;
 
     fill_source_anisotropic(src, flux_);
+    xt::view(src, xt::all(), xt::all(), 0) += extern_src_;
 
     // Check for negative zero moment source values at beginning of simulation
     bool set_neg_src_to_zero = false;

--- a/src/scarabee/_scarabee/python/moc_driver.cpp
+++ b/src/scarabee/_scarabee/python/moc_driver.cpp
@@ -22,7 +22,8 @@ void init_MOCDriver(py::module& m) {
                BoundaryCondition /*xmin = BoundaryCondition::Reflective*/,
                BoundaryCondition /*xmax = BoundaryCondition::Reflective*/,
                BoundaryCondition /*ymin = BoundaryCondition::Reflective*/,
-               BoundaryCondition /*ymax = BoundaryCondition::Reflective*/>(),
+               BoundaryCondition /*ymax = BoundaryCondition::Reflective*/,
+               bool /*anisotropic = false*/>(),
            "Initializes a Method of Characteristics problem.\n\n"
            "Parameters\n"
            "----------\n"
@@ -35,12 +36,15 @@ void init_MOCDriver(py::module& m) {
            "yminbc : BoundaryCondition\n"
            "         Boundary condition at the lower y boundary.\n"
            "ymaxbc : BoundaryCondition\n"
-           "         Boundary condition at the upper y boundary.\n",
+           "         Boundary condition at the upper y boundary.\n"
+           "anisotropic: Anisotropic Scattering\n"
+           "             Enable the anisotropic scattering solver.\n",
            py::arg("geometry"),
            py::arg("xminbc") = BoundaryCondition::Reflective,
            py::arg("xmaxbc") = BoundaryCondition::Reflective,
            py::arg("yminbc") = BoundaryCondition::Reflective,
-           py::arg("ymaxbc") = BoundaryCondition::Reflective)
+           py::arg("ymaxbc") = BoundaryCondition::Reflective,
+           py::arg("anisotropic") = false)
 
       .def("generate_tracks",
            py::overload_cast<std::uint32_t, double, PolarQuadrature>(

--- a/src/scarabee/_scarabee/python/moc_driver.cpp
+++ b/src/scarabee/_scarabee/python/moc_driver.cpp
@@ -103,13 +103,13 @@ void init_MOCDriver(py::module& m) {
            "    Direction vector for disambiguating the cell region.\n"
            "g : int\n"
            "    Energy group index.\n"
-           "lg : int\n"
+           "lj : int\n"
            "    Spherical harmonic index. Default is zero.\n\n",
            "Returns\n"
            "-------\n"
            "float\n"
            "     Flux at position r and in group g.\n",
-           py::arg("r"), py::arg("u"), py::arg("g"), py::arg("lg") = 0)
+           py::arg("r"), py::arg("u"), py::arg("g"), py::arg("lj") = 0)
 
       .def("flux",
            py::overload_cast<std::size_t, std::size_t, std::size_t>(
@@ -121,13 +121,13 @@ void init_MOCDriver(py::module& m) {
            "    Flat Source Region index.\n"
            "g : int\n"
            "    Energy group index.\n"
-           "lg : int\n"
+           "lj : int\n"
            "    Spherical harmonic index. Default is zero.\n\n",
            "Returns\n"
            "-------\n"
            "float\n"
            "     Flux FSR i and in group g.\n",
-           py::arg("i"), py::arg("g"), py::arg("lg") = 0)
+           py::arg("i"), py::arg("g"), py::arg("lj") = 0)
 
       .def("volume",
            py::overload_cast<const Vector&, const Direction&>(

--- a/src/scarabee/_scarabee/python/moc_driver.cpp
+++ b/src/scarabee/_scarabee/python/moc_driver.cpp
@@ -17,13 +17,12 @@ using namespace scarabee;
 
 void init_MOCDriver(py::module& m) {
   py::class_<MOCDriver, std::shared_ptr<MOCDriver>>(m, "MOCDriver")
-      .def(py::init<
-               std::shared_ptr<Cartesian2D> /*geometry*/,
-               BoundaryCondition /*xmin = BoundaryCondition::Reflective*/,
-               BoundaryCondition /*xmax = BoundaryCondition::Reflective*/,
-               BoundaryCondition /*ymin = BoundaryCondition::Reflective*/,
-               BoundaryCondition /*ymax = BoundaryCondition::Reflective*/,
-               bool /*anisotropic = false*/>(),
+      .def(py::init<std::shared_ptr<Cartesian2D> /*geometry*/,
+                    BoundaryCondition /*xmin = BoundaryCondition::Reflective*/,
+                    BoundaryCondition /*xmax = BoundaryCondition::Reflective*/,
+                    BoundaryCondition /*ymin = BoundaryCondition::Reflective*/,
+                    BoundaryCondition /*ymax = BoundaryCondition::Reflective*/,
+                    bool /*anisotropic = false*/>(),
            "Initializes a Method of Characteristics problem.\n\n"
            "Parameters\n"
            "----------\n"
@@ -93,8 +92,8 @@ void init_MOCDriver(py::module& m) {
                     "CMFD mesh for convergence acceleration.")
 
       .def("flux",
-           py::overload_cast<const Vector&, const Direction&, std::size_t>(
-               &MOCDriver::flux, py::const_),
+           py::overload_cast<const Vector&, const Direction&, std::size_t,
+                             std::size_t>(&MOCDriver::flux, py::const_),
            "Returns the scalar flux in group g at position r.\n\n"
            "Parameters\n"
            "----------\n"
@@ -103,28 +102,32 @@ void init_MOCDriver(py::module& m) {
            "u : Direction\n"
            "    Direction vector for disambiguating the cell region.\n"
            "g : int\n"
-           "    Energy group index.\n\n",
+           "    Energy group index.\n"
+           "lg : int\n"
+           "    Spherical harmonic index. Default is zero.\n\n",
            "Returns\n"
            "-------\n"
            "float\n"
            "     Flux at position r and in group g.\n",
-           py::arg("r"), py::arg("u"), py::arg("g"))
+           py::arg("r"), py::arg("u"), py::arg("g"), py::arg("lg") = 0)
 
       .def("flux",
-           py::overload_cast<std::size_t, std::size_t>(&MOCDriver::flux,
-                                                       py::const_),
+           py::overload_cast<std::size_t, std::size_t, std::size_t>(
+               &MOCDriver::flux, py::const_),
            "Returns the scalar flux in group g in Flat Source Region i.\n\n"
            "Parameters\n"
            "----------\n"
            "i : int\n"
            "    Flat Source Region index.\n"
            "g : int\n"
-           "    Energy group index.\n\n"
+           "    Energy group index.\n"
+           "lg : int\n"
+           "    Spherical harmonic index. Default is zero.\n\n",
            "Returns\n"
            "-------\n"
            "float\n"
            "     Flux FSR i and in group g.\n",
-           py::arg("i"), py::arg("g"))
+           py::arg("i"), py::arg("g"), py::arg("lg") = 0)
 
       .def("volume",
            py::overload_cast<const Vector&, const Direction&>(

--- a/src/scarabee/_scarabee/python/moc_driver.cpp
+++ b/src/scarabee/_scarabee/python/moc_driver.cpp
@@ -192,6 +192,10 @@ void init_MOCDriver(py::module& m) {
       .def_property_readonly("ngroups", &MOCDriver::ngroups,
                              "Number of energy groups.")
 
+      .def_property_readonly(
+          "num_spherical_harmonics", &MOCDriver::num_spherical_harmonics,
+          "Number of spherical harmonics for storing the flux moments.")
+
       .def_property_readonly("polar_quadrature", &MOCDriver::polar_quadrature,
                              "Quadrature used for polar angle integration.")
 

--- a/src/scarabee/_scarabee/spherical_harmonics.cpp
+++ b/src/scarabee/_scarabee/spherical_harmonics.cpp
@@ -4,158 +4,189 @@
 
 namespace scarabee {
 
-SphericalHarmonics::SphericalHarmonics(const std::size_t& L, const std::vector<double>& azimuthal_angle, const std::vector<double>& polar_angle)
-     : L_(L), Nlj_((L_+1)*(L_+1)) {
-    // calculate associated legendre for all cosine of polar angles,
-    // the polar_angle contains half of the angle between [0, PI/2] 
-    // therefor, evaluate the remaining half between [PI/2 , PI]
-    // if the indexing of angle between [0, PI/2] is i, then
-    // index of next half will be (no of angle ) + i
-    std::size_t n_polar_angle = polar_angle.size();
-    xt::xtensor<double, 2> associated_legendre_;
-    //associated_legendre_ = std::vector<std::vector<double>>(2 * n_polar_angle, std::vector<double>((L_+1)*(L_+2) / 2, 0.));
-    associated_legendre_.resize({2 * n_polar_angle, (L_+1)*(L_+2) / 2});
-    associated_legendre_.fill(0.);
-    const double sqrt_inv_4PI = 0.5 / std::sqrt(PI);
-    std::size_t p = 0;
-    double theta;
-    for (std::size_t pp = 0; pp < 2 * n_polar_angle; pp++){
-        if (pp < n_polar_angle){
-            // first half angles between [0, PI/2]
-            p = pp;
-            theta = polar_angle[p];
-        } else {
-            // remaining half angles between [PI/2, PI]
-            p = pp - n_polar_angle;
-            theta = PI - polar_angle[p];
-        }
-        const double cos_theta = std::cos(theta);
-        std::size_t it_lj = 0;
-        for (std::size_t l = 0; l <= L_; l++){
-            const double factor = std::sqrt(static_cast<double>(2 * l + 1)) * sqrt_inv_4PI;
-            for (std::size_t j = 0; j <= l; j++){
-                const double P_j_l = eval_associated_legendre(l, static_cast<int>(j), cos_theta);
-                if ( j == 0 ){  
-                    // associated_legendre_[pp][it_lj] = factor * P_j_l;
-                    associated_legendre_(pp, it_lj) = factor * P_j_l; 
-                } else {
-                    const double sqrt_lj = std::sqrt(2. * factorial(l-j) / factorial(l+j));
-                    // associated_legendre_[pp][it_lj] = factor * sqrt_lj * P_j_l;
-                    associated_legendre_(pp, it_lj) = factor * sqrt_lj * P_j_l;
-                }
-                it_lj++;
-            }
-        }
-    }
-
-    // calculate the cos and sin of azimuthal angle phi for
-    // angles corresponds to forward and backward direction entry
-    const std::size_t n_azimuthal_angle = azimuthal_angle.size();
-    xt::xtensor<double, 2> cos_phi_;
-    cos_phi_.resize({n_azimuthal_angle * 2, L_});
-    cos_phi_.fill(0.);
-    xt::xtensor<double, 2> sin_phi_;
-    sin_phi_.resize({n_azimuthal_angle * 2, L_});
-    sin_phi_.fill(0.);
-    //cos_phi_ = std::vector<std::vector<double>>(n_azimuthal_angle * 2, std::vector<double>(L_, 0.));
-    //sin_phi_ = std::vector<std::vector<double>>(n_azimuthal_angle * 2, std::vector<double>(L_, 0.));
-    std::size_t m = 0;
-    double phi;
-    for (std::size_t mm = 0; mm < 2 * n_azimuthal_angle; mm++){
-        if (mm < n_azimuthal_angle){
-            // azimuthal angle in the forward direction of tracks
-            m = mm;
-            phi = azimuthal_angle[m];
-        } else {
-            // azimuthal angle in the backward direction of tracks
-            m = mm - n_azimuthal_angle;
-            phi =  PI + azimuthal_angle[m];
-        }
-
-        for (std::size_t j = 1; j <= L_; j++){
-            //cos_phi_[mm][j-1] = std::cos(j * phi);
-            //sin_phi_[mm][j-1] = std::sin(j * phi);
-            cos_phi_(mm, j-1) = std::cos(static_cast<double>(j) * phi);
-            sin_phi_(mm, j-1) = std::sin(static_cast<double>(j) * phi);
-        }
-    }
-
-    // pre-calculate the spherical harmonics for all given azimuthal and polar angles
-    all_harmonics_.resize({2 * n_azimuthal_angle, 2 * n_polar_angle, (L_+1)*(L_+1)});
-    all_harmonics_.fill(0.);
-    for (std::size_t azm = 0; azm < 2 * n_azimuthal_angle; azm++){
-        for (std::size_t p = 0; p < 2 * n_polar_angle; p++){
-            std::size_t it_lj = 0;
-            for (std::size_t l = 0; l <= L_; l++){
-                for (int j = -static_cast<int>(l); j <= static_cast<int>(l); j++){
-                    if (j == 0){
-                        all_harmonics_(azm, p, it_lj) = associated_legendre_(p, l*(l+1) / 2);
-                    } else if (j > 0){
-                        const std::size_t abs_j = std::abs(j);
-                        all_harmonics_(azm, p, it_lj) = associated_legendre_(p, l*(l+1) / 2 + abs_j) * cos_phi_(azm, abs_j-1);
-                    } else {
-                        // j < 0
-                        const std::size_t abs_j = std::abs(j);
-                        all_harmonics_(azm, p, it_lj) = associated_legendre_(p, l*(l+1) / 2 + abs_j) * sin_phi_(azm, abs_j-1);
-                    }
-                    it_lj++;
-                }
-
-            } // all scattering moments
-        } // all polar angles
-    } // all azimuthal angles
-}
-
-
-double SphericalHarmonics::eval_spherical_harmonics(const std::size_t& l, const int& j, const double& theta, const double& phi) const {
-    // theta is the polar angle, get the cosine of it.
-    const double u = std::cos(theta);
-    if ( std::abs(j) > l ){
-        return 0.;
-    } else if ( j > 0 ){
-        const double factor = std::sqrt((2.*static_cast<double>(l) + 1.) * factorial(l -j) / ( 2. * PI * factorial(l+j)));
-        return factor * eval_associated_legendre(l, j, u) * std::cos(j*phi);
-    } else if ( j == 0 ){
-        const double factor = std::sqrt((2.*static_cast<double>(l) + 1.) / (4. * PI));
-        return factor * eval_associated_legendre(l, j, u);
+SphericalHarmonics::SphericalHarmonics(
+    const std::size_t& L, const std::vector<double>& azimuthal_angle,
+    const std::vector<double>& polar_angle)
+    : L_(L), Nlj_((L_ + 1) * (L_ + 1)) {
+  // calculate associated legendre for all cosine of polar angles,
+  // the polar_angle contains half of the angle between [0, PI/2]
+  // therefor, evaluate the remaining half between [PI/2 , PI]
+  // if the indexing of angle between [0, PI/2] is i, then
+  // index of next half will be (no of angle ) + i
+  std::size_t n_polar_angle = polar_angle.size();
+  xt::xtensor<double, 2> associated_legendre_;
+  // associated_legendre_ = std::vector<std::vector<double>>(2 * n_polar_angle,
+  // std::vector<double>((L_+1)*(L_+2) / 2, 0.));
+  associated_legendre_.resize({2 * n_polar_angle, (L_ + 1) * (L_ + 2) / 2});
+  associated_legendre_.fill(0.);
+  const double sqrt_inv_4PI = 0.5 / std::sqrt(PI);
+  std::size_t p = 0;
+  double theta;
+  for (std::size_t pp = 0; pp < 2 * n_polar_angle; pp++) {
+    if (pp < n_polar_angle) {
+      // first half angles between [0, PI/2]
+      p = pp;
+      theta = polar_angle[p];
     } else {
-        // j < 1
-        const auto abs_j = std::abs(j);
-        const double factor = std::sqrt((2.*static_cast<double>(l) + 1.) * factorial(l - abs_j) / (2. * PI * factorial(l + abs_j)));
-        return factor * eval_associated_legendre(l, abs_j, u) * std::sin(abs_j*phi);
+      // remaining half angles between [PI/2, PI]
+      p = pp - n_polar_angle;
+      theta = PI - polar_angle[p];
     }
-
-    // it should not get here.
-    return 0.;
-}
-
-double SphericalHarmonics::eval_associated_legendre(const std::size_t& order, const int& j, const double& x) const {
-    std::size_t abs_j = std::abs(j);
-    const double associated_l = eval_legendre_differentiation(order, abs_j, x);
-    double factor = std::pow(-1., abs_j) * std::pow(1. - x*x, static_cast<double>(abs_j)/2);
-
-    if (j < 0){
-        factor *= std::pow(-1., j) * factorial(order - abs_j) / factorial(order + abs_j);
-    }
-    return factor * associated_l;
-}
-
-double SphericalHarmonics::eval_legendre_differentiation(const std::size_t& order, const std::size_t& n, const double& x) const {
-    if ( n > 0){
-        if (order > 1){ // a recursion relation for order > 1 and n > 0
-            const double term1 = eval_legendre_differentiation(order-1, n, x) * x;
-            const double term2 = static_cast<double>(n) * eval_legendre_differentiation(order-1, n-1, x);
-            const double term3 = eval_legendre_differentiation(order-2, n, x);
-            return (static_cast<double>(2*order - 1)*(term1 + term2) - static_cast<double>(order-1) * term3) / static_cast<double>(order);
-        } else if (order == 1 && n == 1){
-            return 1.;
+    const double cos_theta = std::cos(theta);
+    std::size_t it_lj = 0;
+    for (std::size_t l = 0; l <= L_; l++) {
+      const double factor =
+          std::sqrt(static_cast<double>(2 * l + 1)) * sqrt_inv_4PI;
+      for (std::size_t j = 0; j <= l; j++) {
+        const double P_j_l =
+            eval_associated_legendre(l, static_cast<int>(j), cos_theta);
+        if (j == 0) {
+          // associated_legendre_[pp][it_lj] = factor * P_j_l;
+          associated_legendre_(pp, it_lj) = factor * P_j_l;
+        } else {
+          const double sqrt_lj =
+              std::sqrt(2. * factorial(l - j) / factorial(l + j));
+          // associated_legendre_[pp][it_lj] = factor * sqrt_lj * P_j_l;
+          associated_legendre_(pp, it_lj) = factor * sqrt_lj * P_j_l;
         }
-    } else if (n == 0){ // special case
-        return eval_legendre(order, x);
+        it_lj++;
+      }
+    }
+  }
+
+  // calculate the cos and sin of azimuthal angle phi for
+  // angles corresponds to forward and backward direction entry
+  const std::size_t n_azimuthal_angle = azimuthal_angle.size();
+  xt::xtensor<double, 2> cos_phi_;
+  cos_phi_.resize({n_azimuthal_angle * 2, L_});
+  cos_phi_.fill(0.);
+  xt::xtensor<double, 2> sin_phi_;
+  sin_phi_.resize({n_azimuthal_angle * 2, L_});
+  sin_phi_.fill(0.);
+  // cos_phi_ = std::vector<std::vector<double>>(n_azimuthal_angle * 2,
+  // std::vector<double>(L_, 0.)); sin_phi_ =
+  // std::vector<std::vector<double>>(n_azimuthal_angle * 2,
+  // std::vector<double>(L_, 0.));
+  std::size_t m = 0;
+  double phi;
+  for (std::size_t mm = 0; mm < 2 * n_azimuthal_angle; mm++) {
+    if (mm < n_azimuthal_angle) {
+      // azimuthal angle in the forward direction of tracks
+      m = mm;
+      phi = azimuthal_angle[m];
+    } else {
+      // azimuthal angle in the backward direction of tracks
+      m = mm - n_azimuthal_angle;
+      phi = PI + azimuthal_angle[m];
     }
 
-    // for any n > 0, at order 0 and 1 return 0.
-    return 0.;
+    for (std::size_t j = 1; j <= L_; j++) {
+      // cos_phi_[mm][j-1] = std::cos(j * phi);
+      // sin_phi_[mm][j-1] = std::sin(j * phi);
+      cos_phi_(mm, j - 1) = std::cos(static_cast<double>(j) * phi);
+      sin_phi_(mm, j - 1) = std::sin(static_cast<double>(j) * phi);
+    }
+  }
+
+  // pre-calculate the spherical harmonics for all given azimuthal and polar
+  // angles
+  all_harmonics_.resize(
+      {2 * n_azimuthal_angle, 2 * n_polar_angle, (L_ + 1) * (L_ + 1)});
+  all_harmonics_.fill(0.);
+  for (std::size_t azm = 0; azm < 2 * n_azimuthal_angle; azm++) {
+    for (std::size_t p = 0; p < 2 * n_polar_angle; p++) {
+      std::size_t it_lj = 0;
+      for (std::size_t l = 0; l <= L_; l++) {
+        for (int j = -static_cast<int>(l); j <= static_cast<int>(l); j++) {
+          if (j == 0) {
+            all_harmonics_(azm, p, it_lj) =
+                associated_legendre_(p, l * (l + 1) / 2);
+          } else if (j > 0) {
+            const std::size_t abs_j = std::abs(j);
+            all_harmonics_(azm, p, it_lj) =
+                associated_legendre_(p, l * (l + 1) / 2 + abs_j) *
+                cos_phi_(azm, abs_j - 1);
+          } else {
+            // j < 0
+            const std::size_t abs_j = std::abs(j);
+            all_harmonics_(azm, p, it_lj) =
+                associated_legendre_(p, l * (l + 1) / 2 + abs_j) *
+                sin_phi_(azm, abs_j - 1);
+          }
+          it_lj++;
+        }
+
+      }  // all scattering moments
+    }    // all polar angles
+  }      // all azimuthal angles
 }
 
-} // namespace scarabee
+double SphericalHarmonics::eval_spherical_harmonics(const std::size_t& l,
+                                                    const int& j,
+                                                    const double& theta,
+                                                    const double& phi) const {
+  // theta is the polar angle, get the cosine of it.
+  const double u = std::cos(theta);
+  if (std::abs(j) > l) {
+    return 0.;
+  } else if (j > 0) {
+    const double factor =
+        std::sqrt((2. * static_cast<double>(l) + 1.) * factorial(l - j) /
+                  (2. * PI * factorial(l + j)));
+    return factor * eval_associated_legendre(l, j, u) * std::cos(j * phi);
+  } else if (j == 0) {
+    const double factor =
+        std::sqrt((2. * static_cast<double>(l) + 1.) / (4. * PI));
+    return factor * eval_associated_legendre(l, j, u);
+  } else {
+    // j < 1
+    const auto abs_j = std::abs(j);
+    const double factor =
+        std::sqrt((2. * static_cast<double>(l) + 1.) * factorial(l - abs_j) /
+                  (2. * PI * factorial(l + abs_j)));
+    return factor * eval_associated_legendre(l, abs_j, u) *
+           std::sin(abs_j * phi);
+  }
+
+  // it should not get here.
+  return 0.;
+}
+
+double SphericalHarmonics::eval_associated_legendre(const std::size_t& order,
+                                                    const int& j,
+                                                    const double& x) const {
+  std::size_t abs_j = std::abs(j);
+  const double associated_l = eval_legendre_differentiation(order, abs_j, x);
+  double factor = std::pow(-1., abs_j) *
+                  std::pow(1. - x * x, static_cast<double>(abs_j) / 2);
+
+  if (j < 0) {
+    factor *=
+        std::pow(-1., j) * factorial(order - abs_j) / factorial(order + abs_j);
+  }
+  return factor * associated_l;
+}
+
+double SphericalHarmonics::eval_legendre_differentiation(
+    const std::size_t& order, const std::size_t& n, const double& x) const {
+  if (n > 0) {
+    if (order > 1) {  // a recursion relation for order > 1 and n > 0
+      const double term1 = eval_legendre_differentiation(order - 1, n, x) * x;
+      const double term2 = static_cast<double>(n) *
+                           eval_legendre_differentiation(order - 1, n - 1, x);
+      const double term3 = eval_legendre_differentiation(order - 2, n, x);
+      return (static_cast<double>(2 * order - 1) * (term1 + term2) -
+              static_cast<double>(order - 1) * term3) /
+             static_cast<double>(order);
+    } else if (order == 1 && n == 1) {
+      return 1.;
+    }
+  } else if (n == 0) {  // special case
+    return eval_legendre(order, x);
+  }
+
+  // for any n > 0, at order 0 and 1 return 0.
+  return 0.;
+}
+
+}  // namespace scarabee

--- a/src/scarabee/_scarabee/spherical_harmonics.cpp
+++ b/src/scarabee/_scarabee/spherical_harmonics.cpp
@@ -1,4 +1,5 @@
 #include <utils/spherical_harmonics.hpp>
+#include <utils/constants.hpp>
 
 #include <cmath>
 

--- a/src/scarabee/_scarabee/spherical_harmonics.cpp
+++ b/src/scarabee/_scarabee/spherical_harmonics.cpp
@@ -1,0 +1,161 @@
+#include <utils/spherical_harmonics.hpp>
+
+#include <cmath>
+
+namespace scarabee {
+
+SphericalHarmonics::SphericalHarmonics(const std::size_t& L, const std::vector<double>& azimuthal_angle, const std::vector<double>& polar_angle)
+     : L_(L), Nlj_((L_+1)*(L_+1)) {
+    // calculate associated legendre for all cosine of polar angles,
+    // the polar_angle contains half of the angle between [0, PI/2] 
+    // therefor, evaluate the remaining half between [PI/2 , PI]
+    // if the indexing of angle between [0, PI/2] is i, then
+    // index of next half will be (no of angle ) + i
+    std::size_t n_polar_angle = polar_angle.size();
+    xt::xtensor<double, 2> associated_legendre_;
+    //associated_legendre_ = std::vector<std::vector<double>>(2 * n_polar_angle, std::vector<double>((L_+1)*(L_+2) / 2, 0.));
+    associated_legendre_.resize({2 * n_polar_angle, (L_+1)*(L_+2) / 2});
+    associated_legendre_.fill(0.);
+    const double sqrt_inv_4PI = 0.5 / std::sqrt(PI);
+    std::size_t p = 0;
+    double theta;
+    for (std::size_t pp = 0; pp < 2 * n_polar_angle; pp++){
+        if (pp < n_polar_angle){
+            // first half angles between [0, PI/2]
+            p = pp;
+            theta = polar_angle[p];
+        } else {
+            // remaining half angles between [PI/2, PI]
+            p = pp - n_polar_angle;
+            theta = PI - polar_angle[p];
+        }
+        const double cos_theta = std::cos(theta);
+        std::size_t it_lj = 0;
+        for (std::size_t l = 0; l <= L_; l++){
+            const double factor = std::sqrt(static_cast<double>(2 * l + 1)) * sqrt_inv_4PI;
+            for (std::size_t j = 0; j <= l; j++){
+                const double P_j_l = eval_associated_legendre(l, static_cast<int>(j), cos_theta);
+                if ( j == 0 ){  
+                    // associated_legendre_[pp][it_lj] = factor * P_j_l;
+                    associated_legendre_(pp, it_lj) = factor * P_j_l; 
+                } else {
+                    const double sqrt_lj = std::sqrt(2. * factorial(l-j) / factorial(l+j));
+                    // associated_legendre_[pp][it_lj] = factor * sqrt_lj * P_j_l;
+                    associated_legendre_(pp, it_lj) = factor * sqrt_lj * P_j_l;
+                }
+                it_lj++;
+            }
+        }
+    }
+
+    // calculate the cos and sin of azimuthal angle phi for
+    // angles corresponds to forward and backward direction entry
+    const std::size_t n_azimuthal_angle = azimuthal_angle.size();
+    xt::xtensor<double, 2> cos_phi_;
+    cos_phi_.resize({n_azimuthal_angle * 2, L_});
+    cos_phi_.fill(0.);
+    xt::xtensor<double, 2> sin_phi_;
+    sin_phi_.resize({n_azimuthal_angle * 2, L_});
+    sin_phi_.fill(0.);
+    //cos_phi_ = std::vector<std::vector<double>>(n_azimuthal_angle * 2, std::vector<double>(L_, 0.));
+    //sin_phi_ = std::vector<std::vector<double>>(n_azimuthal_angle * 2, std::vector<double>(L_, 0.));
+    std::size_t m = 0;
+    double phi;
+    for (std::size_t mm = 0; mm < 2 * n_azimuthal_angle; mm++){
+        if (mm < n_azimuthal_angle){
+            // azimuthal angle in the forward direction of tracks
+            m = mm;
+            phi = azimuthal_angle[m];
+        } else {
+            // azimuthal angle in the backward direction of tracks
+            m = mm - n_azimuthal_angle;
+            phi =  PI + azimuthal_angle[m];
+        }
+
+        for (std::size_t j = 1; j <= L_; j++){
+            //cos_phi_[mm][j-1] = std::cos(j * phi);
+            //sin_phi_[mm][j-1] = std::sin(j * phi);
+            cos_phi_(mm, j-1) = std::cos(static_cast<double>(j) * phi);
+            sin_phi_(mm, j-1) = std::sin(static_cast<double>(j) * phi);
+        }
+    }
+
+    // pre-calculate the spherical harmonics for all given azimuthal and polar angles
+    all_harmonics_.resize({2 * n_azimuthal_angle, 2 * n_polar_angle, (L_+1)*(L_+1)});
+    all_harmonics_.fill(0.);
+    for (std::size_t azm = 0; azm < 2 * n_azimuthal_angle; azm++){
+        for (std::size_t p = 0; p < 2 * n_polar_angle; p++){
+            std::size_t it_lj = 0;
+            for (std::size_t l = 0; l <= L_; l++){
+                for (int j = -static_cast<int>(l); j <= static_cast<int>(l); j++){
+                    if (j == 0){
+                        all_harmonics_(azm, p, it_lj) = associated_legendre_(p, l*(l+1) / 2);
+                    } else if (j > 0){
+                        const std::size_t abs_j = std::abs(j);
+                        all_harmonics_(azm, p, it_lj) = associated_legendre_(p, l*(l+1) / 2 + abs_j) * cos_phi_(azm, abs_j-1);
+                    } else {
+                        // j < 0
+                        const std::size_t abs_j = std::abs(j);
+                        all_harmonics_(azm, p, it_lj) = associated_legendre_(p, l*(l+1) / 2 + abs_j) * sin_phi_(azm, abs_j-1);
+                    }
+                    it_lj++;
+                }
+
+            } // all scattering moments
+        } // all polar angles
+    } // all azimuthal angles
+}
+
+
+double SphericalHarmonics::eval_spherical_harmonics(const std::size_t& l, const int& j, const double& theta, const double& phi) const {
+    // theta is the polar angle, get the cosine of it.
+    const double u = std::cos(theta);
+    if ( std::abs(j) > l ){
+        return 0.;
+    } else if ( j > 0 ){
+        const double factor = std::sqrt((2.*static_cast<double>(l) + 1.) * factorial(l -j) / ( 2. * PI * factorial(l+j)));
+        return factor * eval_associated_legendre(l, j, u) * std::cos(j*phi);
+    } else if ( j == 0 ){
+        const double factor = std::sqrt((2.*static_cast<double>(l) + 1.) / (4. * PI));
+        return factor * eval_associated_legendre(l, j, u);
+    } else {
+        // j < 1
+        const auto abs_j = std::abs(j);
+        const double factor = std::sqrt((2.*static_cast<double>(l) + 1.) * factorial(l - abs_j) / (2. * PI * factorial(l + abs_j)));
+        return factor * eval_associated_legendre(l, abs_j, u) * std::sin(abs_j*phi);
+    }
+
+    // it should not get here.
+    return 0.;
+}
+
+double SphericalHarmonics::eval_associated_legendre(const std::size_t& order, const int& j, const double& x) const {
+    std::size_t abs_j = std::abs(j);
+    const double associated_l = eval_legendre_differentiation(order, abs_j, x);
+    double factor = std::pow(-1., abs_j) * std::pow(1. - x*x, static_cast<double>(abs_j)/2);
+
+    if (j < 0){
+        factor *= std::pow(-1., j) * factorial(order - abs_j) / factorial(order + abs_j);
+    }
+    return factor * associated_l;
+}
+
+double SphericalHarmonics::eval_legendre_differentiation(const std::size_t& order, const std::size_t& n, const double& x) const {
+    if ( n > 0){
+        if (order > 1){ // a recursion relation for order > 1 and n > 0
+            const double term1 = eval_legendre_differentiation(order-1, n, x) * x;
+            const double term2 = static_cast<double>(n) * eval_legendre_differentiation(order-1, n-1, x);
+            const double term3 = eval_legendre_differentiation(order-2, n, x);
+            return (static_cast<double>(2*order - 1)*(term1 + term2) - static_cast<double>(order-1) * term3) / static_cast<double>(order);
+        } else if (order == 1 && n == 1){
+            return 1.;
+        }
+    } else if (n == 0){ // special case
+        return eval_legendre(order, x);
+    }
+
+    // for any n > 0, at order 0 and 1 return 0.
+    return 0.;
+}
+
+} // namespace scarabee

--- a/src/scarabee/_scarabee/spherical_harmonics.cpp
+++ b/src/scarabee/_scarabee/spherical_harmonics.cpp
@@ -1,7 +1,6 @@
 #include <utils/spherical_harmonics.hpp>
 #include <utils/constants.hpp>
-
-#include <cmath>
+#include <utils/math.hpp>
 
 namespace scarabee {
 
@@ -9,185 +8,45 @@ SphericalHarmonics::SphericalHarmonics(
     const std::size_t& L, const std::vector<double>& azimuthal_angle,
     const std::vector<double>& polar_angle)
     : L_(L), Nlj_((L_ + 1) * (L_ + 1)) {
-  // calculate associated legendre for all cosine of polar angles,
   // the polar_angle contains half of the angle between [0, PI/2]
   // therefor, evaluate the remaining half between [PI/2 , PI]
   // if the indexing of angle between [0, PI/2] is i, then
   // index of next half will be (no of angle ) + i
+  // Similarly, azimuthal angles are given between [0, PI] corresponds to
+  // forward direction therefore, elvauate the backward direction entry
+  // azimuthal angles
   std::size_t n_polar_angle = polar_angle.size();
-  xt::xtensor<double, 2> associated_legendre_;
-  // associated_legendre_ = std::vector<std::vector<double>>(2 * n_polar_angle,
-  // std::vector<double>((L_+1)*(L_+2) / 2, 0.));
-  associated_legendre_.resize({2 * n_polar_angle, (L_ + 1) * (L_ + 2) / 2});
-  associated_legendre_.fill(0.);
-  const double sqrt_inv_4PI = 0.5 / std::sqrt(PI);
-  std::size_t p = 0;
   double theta;
-  for (std::size_t pp = 0; pp < 2 * n_polar_angle; pp++) {
-    if (pp < n_polar_angle) {
-      // first half angles between [0, PI/2]
-      p = pp;
-      theta = polar_angle[p];
-    } else {
-      // remaining half angles between [PI/2, PI]
-      p = pp - n_polar_angle;
-      theta = PI - polar_angle[p];
-    }
-    const double cos_theta = std::cos(theta);
-    std::size_t it_lj = 0;
-    for (std::size_t l = 0; l <= L_; l++) {
-      const double factor =
-          std::sqrt(static_cast<double>(2 * l + 1)) * sqrt_inv_4PI;
-      for (std::size_t j = 0; j <= l; j++) {
-        const double P_j_l =
-            eval_associated_legendre(l, static_cast<int>(j), cos_theta);
-        if (j == 0) {
-          // associated_legendre_[pp][it_lj] = factor * P_j_l;
-          associated_legendre_(pp, it_lj) = factor * P_j_l;
-        } else {
-          const double sqrt_lj =
-              std::sqrt(2. * factorial(l - j) / factorial(l + j));
-          // associated_legendre_[pp][it_lj] = factor * sqrt_lj * P_j_l;
-          associated_legendre_(pp, it_lj) = factor * sqrt_lj * P_j_l;
-        }
-        it_lj++;
-      }
-    }
-  }
 
-  // calculate the cos and sin of azimuthal angle phi for
-  // angles corresponds to forward and backward direction entry
   const std::size_t n_azimuthal_angle = azimuthal_angle.size();
-  xt::xtensor<double, 2> cos_phi_;
-  cos_phi_.resize({n_azimuthal_angle * 2, L_});
-  cos_phi_.fill(0.);
-  xt::xtensor<double, 2> sin_phi_;
-  sin_phi_.resize({n_azimuthal_angle * 2, L_});
-  sin_phi_.fill(0.);
-  // cos_phi_ = std::vector<std::vector<double>>(n_azimuthal_angle * 2,
-  // std::vector<double>(L_, 0.)); sin_phi_ =
-  // std::vector<std::vector<double>>(n_azimuthal_angle * 2,
-  // std::vector<double>(L_, 0.));
-  std::size_t m = 0;
   double phi;
-  for (std::size_t mm = 0; mm < 2 * n_azimuthal_angle; mm++) {
-    if (mm < n_azimuthal_angle) {
-      // azimuthal angle in the forward direction of tracks
-      m = mm;
-      phi = azimuthal_angle[m];
-    } else {
-      // azimuthal angle in the backward direction of tracks
-      m = mm - n_azimuthal_angle;
-      phi = PI + azimuthal_angle[m];
-    }
 
-    for (std::size_t j = 1; j <= L_; j++) {
-      // cos_phi_[mm][j-1] = std::cos(j * phi);
-      // sin_phi_[mm][j-1] = std::sin(j * phi);
-      cos_phi_(mm, j - 1) = std::cos(static_cast<double>(j) * phi);
-      sin_phi_(mm, j - 1) = std::sin(static_cast<double>(j) * phi);
-    }
-  }
-
-  // pre-calculate the spherical harmonics for all given azimuthal and polar
-  // angles
   all_harmonics_.resize(
       {2 * n_azimuthal_angle, 2 * n_polar_angle, (L_ + 1) * (L_ + 1)});
   all_harmonics_.fill(0.);
+
   for (std::size_t azm = 0; azm < 2 * n_azimuthal_angle; azm++) {
+    if (azm < n_azimuthal_angle)
+      phi = azimuthal_angle[azm];
+    else
+      phi = azimuthal_angle[azm - n_azimuthal_angle] + PI;
+
     for (std::size_t p = 0; p < 2 * n_polar_angle; p++) {
+      if (p < n_polar_angle)
+        theta = polar_angle[p];
+      else
+        theta = PI - polar_angle[p - n_polar_angle];
+
       std::size_t it_lj = 0;
-      for (std::size_t l = 0; l <= L_; l++) {
+      for (unsigned int l = 0; l <= L_; l++) {
         for (int j = -static_cast<int>(l); j <= static_cast<int>(l); j++) {
-          if (j == 0) {
-            all_harmonics_(azm, p, it_lj) =
-                associated_legendre_(p, l * (l + 1) / 2);
-          } else if (j > 0) {
-            const std::size_t abs_j = std::abs(j);
-            all_harmonics_(azm, p, it_lj) =
-                associated_legendre_(p, l * (l + 1) / 2 + abs_j) *
-                cos_phi_(azm, abs_j - 1);
-          } else {
-            // j < 0
-            const std::size_t abs_j = std::abs(j);
-            all_harmonics_(azm, p, it_lj) =
-                associated_legendre_(p, l * (l + 1) / 2 + abs_j) *
-                sin_phi_(azm, abs_j - 1);
-          }
+          all_harmonics_(azm, p, it_lj) = spherical_hamonics(l, j, phi, theta);
           it_lj++;
         }
 
       }  // all scattering moments
     }    // all polar angles
   }      // all azimuthal angles
-}
-
-double SphericalHarmonics::eval_spherical_harmonics(const std::size_t& l,
-                                                    const int& j,
-                                                    const double& theta,
-                                                    const double& phi) const {
-  // theta is the polar angle, get the cosine of it.
-  const double u = std::cos(theta);
-  if (std::abs(j) > l) {
-    return 0.;
-  } else if (j > 0) {
-    const double factor =
-        std::sqrt((2. * static_cast<double>(l) + 1.) * factorial(l - j) /
-                  (2. * PI * factorial(l + j)));
-    return factor * eval_associated_legendre(l, j, u) * std::cos(j * phi);
-  } else if (j == 0) {
-    const double factor =
-        std::sqrt((2. * static_cast<double>(l) + 1.) / (4. * PI));
-    return factor * eval_associated_legendre(l, j, u);
-  } else {
-    // j < 1
-    const auto abs_j = std::abs(j);
-    const double factor =
-        std::sqrt((2. * static_cast<double>(l) + 1.) * factorial(l - abs_j) /
-                  (2. * PI * factorial(l + abs_j)));
-    return factor * eval_associated_legendre(l, abs_j, u) *
-           std::sin(abs_j * phi);
-  }
-
-  // it should not get here.
-  return 0.;
-}
-
-double SphericalHarmonics::eval_associated_legendre(const std::size_t& order,
-                                                    const int& j,
-                                                    const double& x) const {
-  std::size_t abs_j = std::abs(j);
-  const double associated_l = eval_legendre_differentiation(order, abs_j, x);
-  double factor = std::pow(-1., abs_j) *
-                  std::pow(1. - x * x, static_cast<double>(abs_j) / 2);
-
-  if (j < 0) {
-    factor *=
-        std::pow(-1., j) * factorial(order - abs_j) / factorial(order + abs_j);
-  }
-  return factor * associated_l;
-}
-
-double SphericalHarmonics::eval_legendre_differentiation(
-    const std::size_t& order, const std::size_t& n, const double& x) const {
-  if (n > 0) {
-    if (order > 1) {  // a recursion relation for order > 1 and n > 0
-      const double term1 = eval_legendre_differentiation(order - 1, n, x) * x;
-      const double term2 = static_cast<double>(n) *
-                           eval_legendre_differentiation(order - 1, n - 1, x);
-      const double term3 = eval_legendre_differentiation(order - 2, n, x);
-      return (static_cast<double>(2 * order - 1) * (term1 + term2) -
-              static_cast<double>(order - 1) * term3) /
-             static_cast<double>(order);
-    } else if (order == 1 && n == 1) {
-      return 1.;
-    }
-  } else if (n == 0) {  // special case
-    return eval_legendre(order, x);
-  }
-
-  // for any n > 0, at order 0 and 1 return 0.
-  return 0.;
 }
 
 }  // namespace scarabee

--- a/src/scarabee/_scarabee/track.cpp
+++ b/src/scarabee/_scarabee/track.cpp
@@ -6,7 +6,8 @@ namespace scarabee {
 
 Track::Track(const Vector& entry, const Vector& exit, const Direction& dir,
              double phi, double wgt, double width,
-             const std::vector<Segment>& segments)
+             const std::vector<Segment>& segments,
+             std::size_t forward_phi_index, std::size_t backward_phi_index)
     : entry_flux_(),
       exit_flux_(),
       segments_(segments),
@@ -19,7 +20,9 @@ Track::Track(const Vector& entry, const Vector& exit, const Direction& dir,
       width_(width),
       phi_(phi),
       entry_bc_(BoundaryCondition::Reflective),
-      exit_bc_(BoundaryCondition::Reflective) {}
+      exit_bc_(BoundaryCondition::Reflective),
+      forward_phi_index_(forward_phi_index),
+      backward_phi_index_(backward_phi_index) {}
 
 Segment& Track::at(std::size_t i) {
   if (i >= this->size()) {

--- a/src/scarabee/_scarabee/yamamoto_tabuchi.cpp
+++ b/src/scarabee/_scarabee/yamamoto_tabuchi.cpp
@@ -19,7 +19,8 @@ const std::array<double, 1> YamamotoTabuchi<2>::wgt_ = {1.000000};
 template <>
 const std::array<double, 1> YamamotoTabuchi<2>::wsin_ = {wgt_[0] * sin_[0]};
 template <>
-const std::array<double, 1> YamamotoTabuchi<2>::polar_angle_ = {std::asin(sin_[0])};
+const std::array<double, 1> YamamotoTabuchi<2>::polar_angle_ = {
+    std::asin(sin_[0])};
 
 // N = 4
 template <>
@@ -33,7 +34,8 @@ template <>
 const std::array<double, 2> YamamotoTabuchi<4>::wsin_ = {wgt_[0] * sin_[0],
                                                          wgt_[1] * sin_[1]};
 template <>
-const std::array<double, 2> YamamotoTabuchi<4>::polar_angle_ = {std::asin(sin_[0]), std::asin(sin_[1])};
+const std::array<double, 2> YamamotoTabuchi<4>::polar_angle_ = {
+    std::asin(sin_[0]), std::asin(sin_[1])};
 
 // N = 6
 template <>
@@ -49,6 +51,7 @@ template <>
 const std::array<double, 3> YamamotoTabuchi<6>::wsin_ = {
     wgt_[0] * sin_[0], wgt_[1] * sin_[1], wgt_[2] * sin_[2]};
 template <>
-const std::array<double, 3> YamamotoTabuchi<6>::polar_angle_ = {std::asin(sin_[0]), std::asin(sin_[1]), std::asin(sin_[2])};
+const std::array<double, 3> YamamotoTabuchi<6>::polar_angle_ = {
+    std::asin(sin_[0]), std::asin(sin_[1]), std::asin(sin_[2])};
 
 }  // namespace scarabee

--- a/src/scarabee/_scarabee/yamamoto_tabuchi.cpp
+++ b/src/scarabee/_scarabee/yamamoto_tabuchi.cpp
@@ -1,5 +1,7 @@
 #include <moc/quadrature/yamamoto_tabuchi.hpp>
 
+#include <cmath>
+
 namespace scarabee {
 
 // A. YAMAMOTO, M. TABUCHI, N. SUGIMURA, T. USHIO, and M. MORI, “Derivation of
@@ -16,6 +18,8 @@ template <>
 const std::array<double, 1> YamamotoTabuchi<2>::wgt_ = {1.000000};
 template <>
 const std::array<double, 1> YamamotoTabuchi<2>::wsin_ = {wgt_[0] * sin_[0]};
+template <>
+const std::array<double, 1> YamamotoTabuchi<2>::polar_angle_ = {std::asin(sin_[0])};
 
 // N = 4
 template <>
@@ -28,6 +32,8 @@ const std::array<double, 2> YamamotoTabuchi<4>::wgt_ = {0.212854, 0.787146};
 template <>
 const std::array<double, 2> YamamotoTabuchi<4>::wsin_ = {wgt_[0] * sin_[0],
                                                          wgt_[1] * sin_[1]};
+template <>
+const std::array<double, 2> YamamotoTabuchi<4>::polar_angle_ = {std::asin(sin_[0]), std::asin(sin_[1])};
 
 // N = 6
 template <>
@@ -42,5 +48,7 @@ const std::array<double, 3> YamamotoTabuchi<6>::wgt_ = {0.046233, 0.283619,
 template <>
 const std::array<double, 3> YamamotoTabuchi<6>::wsin_ = {
     wgt_[0] * sin_[0], wgt_[1] * sin_[1], wgt_[2] * sin_[2]};
+template <>
+const std::array<double, 3> YamamotoTabuchi<6>::polar_angle_ = {std::asin(sin_[0]), std::asin(sin_[1]), std::asin(sin_[2])};
 
 }  // namespace scarabee


### PR DESCRIPTION
This PR incorporates the anisotropic scattering in the MOC solver. In this implementation, the spherical harmonics function is used to represent the angular flux. Primarily, two important methods are added in the `MOCDriver` class to solve the anisotropic scattering. User can enable the anisotropic scattering solver at the time of construction of `MOCDriver` in the python interface, See the examples: `slab_anisotropic.py` and `cylinder_anisotropic.py`

The Methods to tackle the anisotropic scattering:

First, `MOCDriver::fill_source_anisotropic` calculates the moments of the source term. Second, `MOCDriver::sweep_anisotropic` function performs the sweep. The sweep in this method follows the same pattern as isotropic. Except, the flux moments are being calculated for all given moments. These flux moments are evaluated using spherical harmonics at a given azimuthal angle and polar angle. The azimuthal angles are taken along the track and polar angles are taken from the polar quadrature. 

