### PR TITLE
Move From GPL to LGPL License

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,169 @@
+                   GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+
+  This version of the GNU Lesser General Public License incorporates
+the terms and conditions of version 3 of the GNU General Public
+License, supplemented by the additional permissions listed below.
+
+  0. Additional Definitions.
+
+  As used herein, "this License" refers to version 3 of the GNU Lesser
+General Public License, and the "GNU GPL" refers to version 3 of the GNU
+General Public License.
+
+  "The Library" refers to a covered work governed by this License,
+other than an Application or a Combined Work as defined below.
+
+  An "Application" is any work that makes use of an interface provided
+by the Library, but which is not otherwise based on the Library.
+Defining a subclass of a class defined by the Library is deemed a mode
+of using an interface provided by the Library.
+
+  A "Combined Work" is a work produced by combining or linking an
+Application with the Library.  The particular version of the Library
+with which the Combined Work was made is also called the "Linked
+Version".
+
+  The "Minimal Corresponding Source" for a Combined Work means the
+Corresponding Source for the Combined Work, excluding any source code
+for portions of the Combined Work that, considered in isolation, are
+based on the Application, and not on the Linked Version.
+
+  The "Corresponding Application Code" for a Combined Work means the
+object code and/or source code for the Application, including any data
+and utility programs needed for reproducing the Combined Work from the
+Application, but excluding the System Libraries of the Combined Work.
+
+  1. Exception to Section 3 of the GNU GPL.
+
+  You may convey a covered work under sections 3 and 4 of this License
+without being bound by section 3 of the GNU GPL.
+
+  2. Conveying Modified Versions.
+
+  If you modify a copy of the Library, and, in your modifications, a
+facility refers to a function or data to be supplied by an Application
+that uses the facility (other than as an argument passed when the
+facility is invoked), then you may convey a copy of the modified
+version:
+
+   a) under this License, provided that you make a good faith effort to
+   ensure that, in the event an Application does not supply the
+   function or data, the facility still operates, and performs
+   whatever part of its purpose remains meaningful, or
+
+   b) under the GNU GPL, with none of the additional permissions of
+   this License applicable to that copy.
+
+  3. Object Code Incorporating Material from Library Header Files.
+
+  The object code form of an Application may incorporate material from
+a header file that is part of the Library.  You may convey such object
+code under terms of your choice, provided that, if the incorporated
+material is not limited to numerical parameters, data structure
+layouts and accessors, or small macros, inline functions and templates
+(ten or fewer lines in length), you do both of the following:
+
+   a) Give prominent notice with each copy of the object code that the
+   Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the object code with a copy of the GNU GPL and this license
+   document.
+
+  4. Combined Works.
+
+  You may convey a Combined Work under terms of your choice that,
+taken together, effectively do not restrict modification of the
+portions of the Library contained in the Combined Work and reverse
+engineering for debugging such modifications, if you also do each of
+the following:
+
+   a) Give prominent notice with each copy of the Combined Work that
+   the Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the Combined Work with a copy of the GNU GPL and this license
+   document.
+
+   c) For a Combined Work that displays copyright notices during
+   execution, include the copyright notice for the Library among
+   these notices, as well as a reference directing the user to the
+   copies of the GNU GPL and this license document.
+
+   d) Do one of the following:
+
+       0) Convey the Minimal Corresponding Source under the terms of this
+       License, and the Corresponding Application Code in a form
+       suitable for, and under terms that permit, the user to
+       recombine or relink the Application with a modified version of
+       the Linked Version to produce a modified Combined Work, in the
+       manner specified by section 6 of the GNU GPL for conveying
+       Corresponding Source.
+
+       1) Use a suitable shared library mechanism for linking with the
+       Library.  A suitable mechanism is one that (a) uses at run time
+       a copy of the Library already present on the user's computer
+       system, and (b) will operate properly with a modified version
+       of the Library that is interface-compatible with the Linked
+       Version.
+
+   e) Provide Installation Information, but only if you would otherwise
+   be required to provide such information under section 6 of the
+   GNU GPL, and only to the extent that such information is
+   necessary to install and execute a modified version of the
+   Combined Work produced by recombining or relinking the
+   Application with a modified version of the Linked Version. (If
+   you use option 4d0, the Installation Information must accompany
+   the Minimal Corresponding Source and Corresponding Application
+   Code. If you use option 4d1, you must provide the Installation
+   Information in the manner specified by section 6 of the GNU GPL
+   for conveying Corresponding Source.)
+
+  5. Combined Libraries.
+
+  You may place library facilities that are a work based on the
+Library side by side in a single library together with other library
+facilities that are not Applications and are not covered by this
+License, and convey such a combined library under terms of your
+choice, if you do both of the following:
+
+   a) Accompany the combined library with a copy of the same work based
+   on the Library, uncombined with any other library facilities,
+   conveyed under the terms of this License.
+
+   b) Give prominent notice with the combined library that part of it
+   is a work based on the Library, and explaining where to find the
+   accompanying uncombined form of the same work.
+
+  6. Revised Versions of the GNU Lesser General Public License.
+
+  The Free Software Foundation may publish revised and/or new versions
+of the GNU Lesser General Public License from time to time. Such new
+versions will be similar in spirit to the present version, but may
+differ in detail to address new problems or concerns.
+
+  Each version is given a distinguishing version number. If the
+Library as you received it specifies that a certain numbered version
+of the GNU Lesser General Public License "or any later version"
+applies to it, you have the option of following the terms and
+conditions either of that published version or of any later version
+published by the Free Software Foundation. If the Library as you
+received it does not specify a version number of the GNU Lesser
+General Public License, you may choose any version of the GNU Lesser
+General Public License ever published by the Free Software Foundation.
+
+  If the Library as you received it specifies that a proxy can decide
+whether future versions of the GNU Lesser General Public License shall
+apply, that proxy's public statement of acceptance of any version is
+permanent authorization for you to choose that version for the
+Library.
+
                     GNU GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Scarabée
 [![Documentation Status](https://readthedocs.org/projects/scarabee/badge/?version=latest)](https://scarabee.readthedocs.io/en/latest/?badge=latest)
-[![License](https://img.shields.io/badge/License-GPLv3-brightgreen)](https://github.com/HunterBelanger/scarabee/blob/master/LICENSE)
+[![License](https://img.shields.io/badge/License-LGPLv3-brightgreen)](https://github.com/HunterBelanger/scarabee/blob/master/LICENSE)
 
 Scarabée is a simplified lattice physics code for light water reactor (LWR)
 neutronics calculations. It currently has the following features:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ authors = [
 dependencies = ["numpy"]
 description = "A lattice physics code for LWR analysis."
 readme = "README.md"
-license = "GPL-3.0-only"
+license = "LGPL-3.0-or-later"
 license-files = ["LICENSE"]
 requires-python = ">=3.10"
 keywords = ["lattice physics", "reactor physics", "neutron transport", "LWR"]

--- a/src/scarabee/_scarabee/python/scarabee.cpp
+++ b/src/scarabee/_scarabee/python/scarabee.cpp
@@ -94,7 +94,7 @@ PYBIND11_MODULE(_scarabee, m, py::mod_gil_not_used()) {
 
   m.attr("__author__") = "Hunter Belanger";
   m.attr("__copyright__") = "Copyright 2024-2025, Hunter Belanger";
-  m.attr("__license__") = "GPL-3.0-or-later";
+  m.attr("__license__") = "LGPL-3.0-or-later";
   m.attr("__maintainer__") = "Hunter Belanger";
   m.attr("__email__") = "hunter.belanger@gmail.com";
   m.attr("__version__") = scarabee::VERSION_STRING;


### PR DESCRIPTION
Hi @2018uch0002 and @gaiarj !

After having had many conversations with colleagues over the past few months, and thinking about it for quite a while along with some research, I think it might be beneficial re-license the project under a different open-source license. Currently, we are using version 3 of the GNU General Public License (GPL). This means that Scarabée is "copy-left", so anyone who uses it in their projects must ALSO release their code under the GPL, maintaining the open-sourced goodness ( 😃  open-source ! ). However, most other open-source projects in the community use other licenses that are "permissive" like the MIT license, which says people can do whatever they want with your code and it doesn't even need to be open-source after (OpenMC is an example of this). Unfortunately, projects that want to use a permissive license cannot use any of our code 😢, as it would "infect" their project, making it GPL as well.

Another difficulty we have is our intended use case, which is for Scarabée to be used as a Python library. Because we are using the GPL, any Python script that someone writes which uses the Scarabée library must also be released under the GPL, and couldn't be released under another type of open-source license. This is admittedly not the desired intent at least the way I saw things. I want people to use Scarabée and do cool things with it and teach great reactor physics courses, but that doesn't require forcing them into using the GPL after. This might also scare away potential users.

Because of these two points, I think we should move to version 3 of the GNU Lesser General Public License (LGPL). This license lets people "link" against Scarabée (i.e. use it in a Python script) without forcing them to license their script under the same license; they can choose whatever license they want, or of course keep it propriety (this is fine for me, I honestly don't care about boring assembly input scripts 😅 ). BUT, if someone takes the Scarabée code directly and modifies it, that must still be license according to the LGPL. I see this as the best of both worlds: we ensure Scarabée remains open-source and that we can get back improvements people might make, but we also allow users who aren't necessarily developing it, but just using it, to use whatever license they would like for their Python scripts. Other open-source projects will also be able to use our code far more easily too without needing to change their license.

Since both of you have contributed code to the project, both of you should agree to this change on this thread before I can make the change. If you are both in agreement for making this change, I will amend the commit to add you both as co-authors to the license change commit, and then merge it. All subsequent releases of Scarabée will then be under the LGPL license.