### PR TITLE
Nodal Diffusion Solver with CMFD Acceleration

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -18,12 +18,12 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest, macos-15-intel]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v3.3.1
+        uses: pypa/cibuildwheel@v3.4.1
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
           path: ./wheelhouse/*.whl

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,12 +23,12 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
-      - name: Set up Python 3.11
-        uses: actions/setup-python@v4
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v6
         with:
-          python-version: '3.11'
+          python-version: '3.12'
 
       - name: Install Python dependencies
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,14 +100,14 @@ set(PYBIND11_NEWPYTHON ON)
 find_package(pybind11 CONFIG QUIET)
 if (NOT pybind11_FOUND)
   set(PYBIND11_FINDPYTHON ON)
-  message(STATUS "Downloading pybind11 v3.0.2")
+  message(STATUS "Downloading pybind11 v3.0.4")
   FetchContent_Declare(pybind11
-    URL https://github.com/pybind/pybind11/archive/refs/tags/v3.0.2.tar.gz
-    URL_HASH MD5=6d7134a90dab46b0a7f7bcf9c05aa10c
+    URL https://github.com/pybind/pybind11/archive/refs/tags/v3.0.4.tar.gz
+    URL_HASH MD5=933fa1b6b1fe34c9945ecb3fe67f5c4b
   )
   FetchContent_MakeAvailable(pybind11)
   if (NOT pybind11_VERSION)
-    set(pybind11_VERSION 3.0.2)
+    set(pybind11_VERSION 3.0.4)
   endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -258,6 +258,7 @@ pybind11_add_module(_scarabee src/scarabee/_scarabee/constants.cpp
                               src/scarabee/_scarabee/python/diffusion_geometry.cpp
                               src/scarabee/_scarabee/python/fd_diffusion_driver.cpp
                               src/scarabee/_scarabee/python/nem_diffusion_driver.cpp
+                              src/scarabee/_scarabee/python/nodal_diffusion_driver.cpp
                               src/scarabee/_scarabee/python/reflector_sn.cpp
                               src/scarabee/_scarabee/python/water.cpp
                               src/scarabee/_scarabee/python/depletion_chain.cpp

--- a/docs/source/api/diffusion.rst
+++ b/docs/source/api/diffusion.rst
@@ -20,3 +20,7 @@ Diffusion
 .. autoclass:: scarabee.FDDiffusionDriver
 
 .. autoclass:: scarabee.NEMDiffusionDriver
+
+.. autoclass:: scarabee.FDNodalDiffusionDriver
+
+.. autoclass:: scarabee.NEM4DiffusionDriver

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -97,7 +97,7 @@ mathjax3_config = {
     'packages': {'[+]': ['newcommand', 'physics', 'boldsymbol']},
     'macros': {
       'pos': '\\boldsymbol{r}',
-      'dir': '\\boldsymbol{\hat{\Omega}}',
+      'dir': '\\boldsymbol{\\hat{\\Omega}}',
       'Et': '\\Sigma_t',
       'Es': '\\Sigma_s',
       'Ea': '\\Sigma_a',

--- a/docs/source/releasenotes/upcoming.rst
+++ b/docs/source/releasenotes/upcoming.rst
@@ -2,6 +2,25 @@
 Upcoming Release Notes
 ======================
 
+------------
+New Features
+------------
+
+- A new nodal diffusion solver based on the nodal CMFD method with 2-node current
+  calculations has been added. This new solver, called `NEM4DiffusionDriver` is
+  approximately 10 times faster than the previous `NEMDiffusionDriver` solver which was
+  based on the method of interface currents. It has an identical interface to the
+  previous solver (with a few added elements), and should work as a drop in replacement.
+  As such, the previous `NEMDiffusionDriver` has been deprecated. The motivation behind
+  this new solver is not purely the better run time performance, but it is written in
+  such a way that is will be drastically easier to add other nodal methods in the future,
+  such as the Semi-Analytical Nodal Method and the Analytical Nodal Method.
+
+- A new finite-difference diffusion solver, based on the new CMFD nodal kernel method
+  above, has been added. This new solver is called `FDNodalDiffusionDriver`. Currently,
+  there are no plans to deprecate the previous `FDDiffusionDriver` class, as that solver
+  yields superior performance for finite-difference calculations.
+
 ---------
 Bug Fixes
 ---------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
   "scikit-build-core>=0.10",
-  "pybind11==3.0.2",
+  "pybind11==3.0.4",
   "mypy",
   "numpy",
   "scipy"
@@ -11,6 +11,9 @@ build-backend = "scikit_build_core.build"
 [tool.scikit-build]
 sdist.exclude = ["src/scarabee/_scarabee"]
 cmake.build-type = "Release"
+
+[tool.scikit-build.cmake.define]
+NDEBUG = true
 
 [project]
 name = "scarabee"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,16 +12,13 @@ build-backend = "scikit_build_core.build"
 sdist.exclude = ["src/scarabee/_scarabee"]
 cmake.build-type = "Release"
 
-[tool.scikit-build.cmake.define]
-NDEBUG = true
-
 [project]
 name = "scarabee"
 version = "0.1.1"
 authors = [
   {name = "Hunter Belanger", email = "hunter.belanger@gmail.com"},
 ]
-dependencies = ["numpy"]
+dependencies = ["numpy", "scipy"]
 description = "A lattice physics code for LWR analysis."
 readme = "README.md"
 license = "LGPL-3.0-or-later"

--- a/src/scarabee/_scarabee/include/data/diffusion_cross_section.hpp
+++ b/src/scarabee/_scarabee/include/data/diffusion_cross_section.hpp
@@ -39,12 +39,16 @@ class DiffusionCrossSection {
   bool fissile() const { return fissile_; }
 
   double D(std::size_t g) const { return D_(g); }
+  double& D_ref(std::size_t g) { return D_(g); }
 
   double Ea(std::size_t g) const { return Ea_(g); }
+  double& Ea_ref(std::size_t g) { return Ea_(g); }
 
   double Ef(std::size_t g) const { return Ef_(g); }
+  double& Ef_ref(std::size_t g) { return Ef_(g); }
 
   double vEf(std::size_t g) const { return vEf_(g); }
+  double& vEf_ref(std::size_t g) { return vEf_(g); }
 
   double nu(std::size_t g) const {
     const double Efg = Ef_(g);
@@ -57,8 +61,10 @@ class DiffusionCrossSection {
   double Er(std::size_t g) const { return Ea(g) + Es(g) - Es(g, g); }
 
   double chi(std::size_t g) const { return chi_(g); }
+  double& chi_ref(std::size_t g) { return chi_(g); }
 
   double Es(std::size_t gin, std::size_t gout) const { return Es_(gin, gout); }
+  double& Es_ref(std::size_t gin, std::size_t gout) { return Es_(gin, gout); }
 
   double Es(std::size_t gin) const {
     return xt::sum(xt::view(Es_, gin, xt::all()))();
@@ -82,10 +88,6 @@ class DiffusionCrossSection {
   bool fissile_;
 
   void check_xs();
-
-  // This is needed so that the NEM solver can update cross sections for
-  // leakakge durring the solve
-  friend class NEMDiffusionDriver;
 
   friend class cereal::access;
   DiffusionCrossSection() {}

--- a/src/scarabee/_scarabee/include/diffusion/diffusion_geometry.hpp
+++ b/src/scarabee/_scarabee/include/diffusion/diffusion_geometry.hpp
@@ -37,7 +37,7 @@ class DiffusionGeometry {
   using TileFill = std::variant<double, std::shared_ptr<DiffusionData>,
                                 std::shared_ptr<DiffusionCrossSection>>;
 
-  enum class Neighbor : std::uint8_t { XN, XP, YN, YP, ZN, ZP };
+  enum class Neighbor : std::uint8_t { XN = 0, XP = 1, YN = 2, YP = 3, ZN = 4, ZP = 5 };
 
   DiffusionGeometry(const std::vector<TileFill>& tiles,
                     const std::vector<double>& dx,

--- a/src/scarabee/_scarabee/include/diffusion/diffusion_geometry.hpp
+++ b/src/scarabee/_scarabee/include/diffusion/diffusion_geometry.hpp
@@ -37,7 +37,14 @@ class DiffusionGeometry {
   using TileFill = std::variant<double, std::shared_ptr<DiffusionData>,
                                 std::shared_ptr<DiffusionCrossSection>>;
 
-  enum class Neighbor : std::uint8_t { XN = 0, XP = 1, YN = 2, YP = 3, ZN = 4, ZP = 5 };
+  enum class Neighbor : std::uint8_t {
+    XN = 0,
+    XP = 1,
+    YN = 2,
+    YP = 3,
+    ZN = 4,
+    ZP = 5
+  };
 
   DiffusionGeometry(const std::vector<TileFill>& tiles,
                     const std::vector<double>& dx,

--- a/src/scarabee/_scarabee/include/diffusion/finite_difference.hpp
+++ b/src/scarabee/_scarabee/include/diffusion/finite_difference.hpp
@@ -1,0 +1,119 @@
+#ifndef SCARABEE_FINITE_DIFFERENCE_H
+#define SCARABEE_FINITE_DIFFERENCE_H
+
+#include <diffusion/nodal_method.hpp>
+#include <data/diffusion_cross_section.hpp>
+
+#include <array>
+#include <cstddef>
+#include <span>
+
+namespace scarabee {
+
+class FiniteDifference {
+ public:
+  FiniteDifference(std::size_t /*NG*/) {}
+
+  static constexpr bool update_currents{false};
+
+  void compute_keff_nonlinear_diffusion_coefficient(
+      std::span<const Node> lnode, const Side side, std::span<const Node> rnode,
+      std::span<const double> D, const DiffusionCrossSection& lxs,
+      const DiffusionCrossSection& rxs, const std::array<double, 3> ld,
+      const std::array<double, 3> rd, std::span<double> Dnl,
+      const double /*invs_keff*/) {
+    // The formula used in the loop below can be derived from setting the last
+    // equation in [1] to be equal to the CMFD current. This allows us to
+    // derive an expression for the nonlinear diffusion coefficient that
+    // preserves the flux discontinuities. If no ADFs are used, Dnl = 0.
+
+    const double ldx = get_node_width(ld, side);
+    const double rdx = get_node_width(rd, side);
+
+    for (std::size_t g = 0; g < Dnl.size(); g++) {
+      const double phi_l = lnode[g].phi0();
+      const double phi_r = rnode[g].phi0();
+      const double f_l = get_adf(lnode[g], side);
+      const double f_r = get_op_adf(rnode[g], side);
+      const double r = f_l / f_r;
+      const double Dl = lxs.D(g);
+      const double Dr = rxs.D(g);
+      const double num =
+          ((2. * Dl * Dr) / (rdx * Dr + r * ldx * Dl)) * (phi_r - r * phi_l) -
+          D[g] * (phi_r - phi_l);
+      const double denom = phi_l + phi_r;
+      Dnl[g] = num / denom;
+    }
+  }
+
+  void compute_keff_nonlinear_diffusion_coefficient(
+      std::span<const Node> /*lnode*/, const Side /*side*/,
+      std::span<const double> /*D*/, double /*B*/,
+      const DiffusionCrossSection& /*lxs*/, const std::array<double, 3> /*ld*/,
+      std::span<double> Dnl, const double /*invs_keff*/) {
+    for (auto& Dg : Dnl) Dg = 0.;
+  }
+
+ private:
+  double get_adf(const Node& n, Side s) const {
+    switch (s) {
+      case Side::XN:
+        return n.adf_xn();
+      case Side::XP:
+        return n.adf_xp();
+      case Side::YN:
+        return n.adf_yn();
+      case Side::YP:
+        return n.adf_yp();
+      case Side::ZN:
+        return n.adf_zn();
+      case Side::ZP:
+        return n.adf_zp();
+      default:
+        return 1;  // Should never get here
+    }
+  }
+
+  double get_op_adf(const Node& n, Side s) const {
+    switch (s) {
+      case Side::XN:
+        return n.adf_xp();
+      case Side::XP:
+        return n.adf_xn();
+      case Side::YN:
+        return n.adf_yp();
+      case Side::YP:
+        return n.adf_yn();
+      case Side::ZN:
+        return n.adf_zp();
+      case Side::ZP:
+        return n.adf_zn();
+      default:
+        return 1.;  // Should never get here
+    }
+  }
+
+  double get_node_width(const std::array<double, 3>& dx, Side side) const {
+    switch (side) {
+      case Side::XP:
+      case Side::XN:
+        return dx[0];
+      case Side::YP:
+      case Side::YN:
+        return dx[1];
+      case Side::ZP:
+      case Side::ZN:
+        return dx[2];
+      default:
+        return dx[0];  // Should never get here !
+    }
+  }
+};
+
+}  // namespace scarabee
+
+// [1] R. Sanchez, G. Dante, and I. Zmijarevic, “DIFFUSION PIECEWISE
+//     HOMOGENIZATION VIA FLUX DISCONTINUITY RATIOS,” Nucl. Eng. Technol.,
+//     vol. 45, no. 6, pp. 707–720, 2013, doi: 10.5516/net.02.2013.518.
+
+#endif

--- a/src/scarabee/_scarabee/include/diffusion/finite_difference.hpp
+++ b/src/scarabee/_scarabee/include/diffusion/finite_difference.hpp
@@ -2,22 +2,28 @@
 #define SCARABEE_FINITE_DIFFERENCE_H
 
 #include <diffusion/nodal_method.hpp>
+#include <diffusion/node.hpp>
 #include <data/diffusion_cross_section.hpp>
+
+#include <cereal/cereal.hpp>
 
 #include <array>
 #include <cstddef>
+#include <cmath>
 #include <span>
 
 namespace scarabee {
 
 class FiniteDifference {
  public:
+  FiniteDifference() = default;
   FiniteDifference(std::size_t /*NG*/) {}
 
   static constexpr bool update_currents{false};
+  static constexpr bool reconstruct_flux{false};
 
-  void compute_keff_nonlinear_diffusion_coefficient(
-      std::span<const Node> lnode, const Side side, std::span<const Node> rnode,
+  double compute_keff_nonlinear_diffusion_coefficient(
+      std::span<Node> lnode, const Side side, std::span<Node> rnode,
       std::span<const double> D, const DiffusionCrossSection& lxs,
       const DiffusionCrossSection& rxs, const std::array<double, 3> ld,
       const std::array<double, 3> rd, std::span<double> Dnl,
@@ -30,6 +36,7 @@ class FiniteDifference {
     const double ldx = get_node_width(ld, side);
     const double rdx = get_node_width(rd, side);
 
+    double max_diff = 0.;
     for (std::size_t g = 0; g < Dnl.size(); g++) {
       const double phi_l = lnode[g].phi0();
       const double phi_r = rnode[g].phi0();
@@ -42,16 +49,22 @@ class FiniteDifference {
           ((2. * Dl * Dr) / (rdx * Dr + r * ldx * Dl)) * (phi_r - r * phi_l) -
           D[g] * (phi_r - phi_l);
       const double denom = phi_l + phi_r;
+
+      const double old_Dnlg = Dnl[g];
       Dnl[g] = num / denom;
+      const double diff = std::abs((Dnl[g] - old_Dnlg) / Dnl[g]);
+      if (diff > max_diff) max_diff = diff;
     }
+    return max_diff;
   }
 
-  void compute_keff_nonlinear_diffusion_coefficient(
-      std::span<const Node> /*lnode*/, const Side /*side*/,
+  double compute_keff_nonlinear_diffusion_coefficient(
+      std::span<Node> /*lnode*/, const Side /*side*/,
       std::span<const double> /*D*/, double /*B*/,
       const DiffusionCrossSection& /*lxs*/, const std::array<double, 3> /*ld*/,
       std::span<double> Dnl, const double /*invs_keff*/) {
     for (auto& Dg : Dnl) Dg = 0.;
+    return 0.;
   }
 
  private:
@@ -108,6 +121,12 @@ class FiniteDifference {
         return dx[0];  // Should never get here !
     }
   }
+
+ private:
+  friend class cereal::access;
+
+  template <class Archive>
+  void serialize(Archive& /*arc*/) {}
 };
 
 }  // namespace scarabee

--- a/src/scarabee/_scarabee/include/diffusion/intra_nodal_flux.hpp
+++ b/src/scarabee/_scarabee/include/diffusion/intra_nodal_flux.hpp
@@ -1,0 +1,91 @@
+#ifndef SCARABEE_INTRA_NODAL_FLUX_H
+#define SCARABEE_INTRA_NODAL_FLUX_H
+
+#include <cereal/cereal.hpp>
+
+#include <cmath>
+
+namespace scarabee {
+
+// The method used for intranodal flux reconstruction is based on ANOVA-HDMR
+// decomposition, as outlined by Bokov et al. [1].
+struct IntraNodalFlux {
+  double phi_0 = 0.;  // f0
+  double eps = 0.;
+  double ax0 = 0., ax1 = 0., ax2 = 0., bx1 = 0., bx2 = 0.;  // fx
+  double ay0 = 0., ay1 = 0., ay2 = 0., by1 = 0., by2 = 0.;  // fy
+  double az0 = 0., az1 = 0., az2 = 0., bz1 = 0., bz2 = 0.;  // fz
+  double cxy11 = 0., cxy12 = 0., cxy21 = 0., cxy22 = 0.;    // fxy
+  double invs_dx = 0., invs_dy = 0., invs_dz = 0.;
+  double zeta_x = 0., zeta_y = 0.;
+  double xm = 0., ym = 0., zm = 0.;  // Mid point of node
+
+  double operator()(double x, double y, double z) const {
+    x -= xm;
+    y -= ym;
+    z -= zm;
+
+    return phi_0 + fx(x) + fy(y) + fz(z) + fxy(x, y);
+  }
+
+  double flux_xy_no_cross(double x, double y) const {
+    x -= xm;
+    y -= ym;
+
+    return phi_0 + fx(x) + fy(y);
+  }
+
+  double fx(double x) const {
+    return ax0 + ax1 * std::cosh(eps * x) + ax2 * std::sinh(eps * x) +
+           bx1 * p1(2. * x * invs_dx) + bx2 * p2(2. * x * invs_dx);
+  }
+
+  double fy(double y) const {
+    return ay0 + ay1 * std::cosh(eps * y) + ay2 * std::sinh(eps * y) +
+           by1 * p1(2. * y * invs_dy) + by2 * p2(2. * y * invs_dy);
+  }
+
+  double fz(double z) const {
+    return az0 + az1 * std::cosh(eps * z) + az2 * std::sinh(eps * z) +
+           bz1 * p1(2. * z * invs_dz) + bz2 * p2(2. * z * invs_dz);
+  }
+
+  double fxy(double x, double y) const {
+    x *= 2. * invs_dx;
+    y *= 2. * invs_dy;
+    const double p1x = p1(x);
+    const double p2x = p2(x);
+    const double p1y = p1(y);
+    const double p2y = p2(y);
+    return cxy11 * p1x * p1y + cxy12 * p1x * p2y + cxy21 * p2x * p1y +
+           cxy22 * p2x * p2y;
+  }
+
+  double p1(double xi) const { return xi; }
+  double p2(double xi) const { return 0.5 * (3. * xi * xi - 1.); }
+
+ private:
+  friend class cereal::access;
+  template <class Archive>
+  void serialize(Archive& arc) {
+    arc(CEREAL_NVP(phi_0), CEREAL_NVP(eps), CEREAL_NVP(ax0), CEREAL_NVP(ax1),
+        CEREAL_NVP(ax2), CEREAL_NVP(bx1), CEREAL_NVP(bx2), CEREAL_NVP(ay0),
+        CEREAL_NVP(ay1), CEREAL_NVP(ay2), CEREAL_NVP(by1), CEREAL_NVP(by2),
+        CEREAL_NVP(az0), CEREAL_NVP(az1), CEREAL_NVP(az2), CEREAL_NVP(bz1),
+        CEREAL_NVP(bz2), CEREAL_NVP(cxy11), CEREAL_NVP(cxy12),
+        CEREAL_NVP(cxy21), CEREAL_NVP(cxy22), CEREAL_NVP(invs_dx),
+        CEREAL_NVP(invs_dy), CEREAL_NVP(invs_dz), CEREAL_NVP(zeta_x),
+        CEREAL_NVP(zeta_y), CEREAL_NVP(xm), CEREAL_NVP(ym), CEREAL_NVP(zm));
+  }
+};
+
+}  // namespace scarabee
+
+// References
+// ----------
+// [1] P. M. Bokov, D. Botes, R. H. Prinsloo, and D. I. Tomašević, “A
+//     Multigroup Homogeneous Flux Reconstruction Method Based on the
+//     ANOVA-HDMR Decomposition,” Nucl. Sci. Eng., vol. 197, no. 2,
+//     pp. 308–332, 2023, doi: 10.1080/00295639.2022.2108654.
+
+#endif

--- a/src/scarabee/_scarabee/include/diffusion/nem4.hpp
+++ b/src/scarabee/_scarabee/include/diffusion/nem4.hpp
@@ -2,9 +2,13 @@
 #define SCARABEE_NEM4_H
 
 #include <diffusion/nodal_method.hpp>
+#include <diffusion/node.hpp>
 #include <data/diffusion_cross_section.hpp>
+#include <utils/serialization.hpp>
 
-#include <Eigen/Sparse>
+#include <Eigen/Dense>
+
+#include <cereal/cereal.hpp>
 
 #include <array>
 #include <cstddef>
@@ -13,110 +17,151 @@
 namespace scarabee {
 
 class NEM4 {
+ private:
+  using Matrix =
+      Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>;
+  using Vector = Eigen::VectorXd;
+  using Solver = Eigen::PartialPivLU<Matrix>;
+
  public:
-  NEM4(std::size_t NG) : M_{}, Q_{}, NG_{NG} {
-    M_.resize(8 * NG, 8 * NG);
-    Q_.resize(8 * NG);
-  }
+  NEM4(std::size_t NG)
+      : M1n_(4 * NG, 4 * NG),
+        M2n_(8 * NG, 8 * NG),
+        Q1n_(4 * NG),
+        Q2n_(8 * NG),
+        A1n_(4 * NG),
+        A2n_(8 * NG),
+        NG_{NG} {}
 
   static constexpr bool update_currents{true};
+  static constexpr bool reconstruct_flux{true};
 
-  void compute_keff_nonlinear_diffusion_coefficient(
-      std::span<const Node> lnode, const Side side, std::span<const Node> rnode,
+  double compute_keff_nonlinear_diffusion_coefficient(
+      std::span<Node> lnode, const Side side, std::span<Node> rnode,
       std::span<const double> D, const DiffusionCrossSection& lxs,
       const DiffusionCrossSection& rxs, const std::array<double, 3> ld,
       const std::array<double, 3> rd, std::span<double> Dnl,
       const double invs_keff) {
     const double invs_ldx = 1. / get_node_width(ld, side);
     const double invs_rdx = 1. / get_node_width(rd, side);
-
-    M_.resize(8 * NG_, 8 * NG_);
-    M_.setZero();
-    Q_.resize(8 * NG_);
-    Q_.setZero();
+    M2n_.setZero();
+    Q2n_.setZero();
 
     // We have 8 equations for each energy group
-    int e = 0;
+    std::size_t e = 0;
     for (std::size_t g = 0; g < NG_; g++) {
       // Flux balance equation for left node
-      fill_neutron_balance(lnode, side, lxs, ld, invs_keff, invs_ldx, g, e++,
-                           0);
-      // fill_neutron_leakage(lnode, side, lxs, invs_ldx, g, e++, 0);
+      fill_neutron_balance(M2n_, Q2n_, lnode, side, lxs, ld, invs_keff,
+                           invs_ldx, g, e++, 0);
       //  Flux balance equation for right node
-      fill_neutron_balance(rnode, side, rxs, rd, invs_keff, invs_rdx, g, e++,
-                           1);
-      // fill_neutron_leakage(rnode, side, rxs, invs_rdx, g, e++, 1);
+      fill_neutron_balance(M2n_, Q2n_, rnode, side, rxs, rd, invs_keff,
+                           invs_rdx, g, e++, 1);
 
       // First moment for left node
-      fill_first_moment(lnode, side, lxs, ld, invs_keff, invs_ldx, g, e++, 0);
+      fill_first_moment(M2n_, Q2n_, lnode, side, lxs, ld, invs_keff, invs_ldx,
+                        g, e++, 0);
       // First moment for right node
-      fill_first_moment(rnode, side, rxs, rd, invs_keff, invs_rdx, g, e++, 1);
+      fill_first_moment(M2n_, Q2n_, rnode, side, rxs, rd, invs_keff, invs_rdx,
+                        g, e++, 1);
 
       // Second moment for left node
-      fill_second_moment(lnode, side, lxs, ld, invs_keff, invs_ldx, g, e++, 0);
+      fill_second_moment(M2n_, Q2n_, lnode, side, lxs, ld, invs_keff, invs_ldx,
+                         g, e++, 0);
       // Second moment for right node
-      fill_second_moment(rnode, side, rxs, rd, invs_keff, invs_rdx, g, e++, 1);
+      fill_second_moment(M2n_, Q2n_, rnode, side, rxs, rd, invs_keff, invs_rdx,
+                         g, e++, 1);
 
       // Flux (dis)continuity condition
-      fill_flux_discontinuity(lnode[g], rnode[g], side, g, e++);
+      fill_flux_discontinuity(M2n_, Q2n_, lnode[g], rnode[g], side, g, e++);
 
       // Current continuity condition
-      fill_current_continuity(lxs, rxs, invs_ldx, invs_rdx, g, e++);
+      fill_current_continuity(M2n_, Q2n_, lxs, rxs, invs_ldx, invs_rdx, g, e++);
     }
 
     // Solve system of equations
-    Eigen::BiCGSTAB<Eigen::SparseMatrix<double, Eigen::RowMajor>> solver;
-    solver.setTolerance(1.E-60);
-    solver.compute(M_);
-    auto A = solver.solve(Q_);
+    Solver solver;
+    solver.compute(M2n_);
+    A2n_ = solver.solve(Q2n_);
+    const auto& A = A2n_;
 
     // Compute current and nonlinear diffusion coefficient for each group
+    double max_diff = 0.;
     for (std::size_t g = 0; g < NG_; g++) {
       const double J = -lxs.D(g) * invs_ldx *
                        (A(ind(g, 0, 1)) + 3. * A(ind(g, 0, 2)) +
                         0.5 * A(ind(g, 0, 3)) + 0.2 * A(ind(g, 0, 4)));
       const double phi_i = lnode[g].phi0();
       const double phi_i1 = rnode[g].phi0();
+      const double old_Dnlg = Dnl[g];
 
       Dnl[g] = -(J + D[g] * (phi_i1 - phi_i)) / (phi_i1 + phi_i);
+      const double diff = std::abs(Dnl[g] - old_Dnlg);
+      if (diff > max_diff) max_diff = diff;
+
+      // Compute surface flux for each side
+      const double lnode_phi_p =
+          lnode[g].phi0() + 0.5 * (A(ind(g, 0, 1)) + A(ind(g, 0, 2)));
+      const double rnode_phi_n =
+          rnode[g].phi0() + 0.5 * (A(ind(g, 1, 2)) - A(ind(g, 1, 1)));
+      switch (side) {
+        case Side::XN:
+        case Side::XP:
+          lnode[g].phi_xp() = lnode_phi_p;
+          rnode[g].phi_xn() = rnode_phi_n;
+          break;
+        case Side::YN:
+        case Side::YP:
+          lnode[g].phi_yp() = lnode_phi_p;
+          rnode[g].phi_yn() = rnode_phi_n;
+          break;
+        case Side::ZN:
+        case Side::ZP:
+          lnode[g].phi_zp() = lnode_phi_p;
+          rnode[g].phi_zn() = rnode_phi_n;
+          break;
+      }
     }
+    return max_diff;
   }
 
-  void compute_keff_nonlinear_diffusion_coefficient(
-      std::span<const Node> node, const Side side, std::span<const double> D,
+  double compute_keff_nonlinear_diffusion_coefficient(
+      std::span<Node> node, const Side side, std::span<const double> D,
       double B, const DiffusionCrossSection& xs, const std::array<double, 3> d,
       std::span<double> Dnl, const double invs_keff) {
     const double invs_dx = 1. / get_node_width(d, side);
-    M_.resize(4 * NG_, 4 * NG_);
-    M_.setZero();
-    Q_.resize(4 * NG_);
-    Q_.setZero();
+    M1n_.setZero();
+    Q1n_.setZero();
 
-    // We have 8 equations for each energy group
-    int e = 0;
+    // We have 4 equations for each energy group
+    std::size_t e = 0;
     for (std::size_t g = 0; g < NG_; g++) {
       // Flux balance equation
-      fill_neutron_balance(node, side, xs, d, invs_keff, invs_dx, g, e++, 0);
-      // fill_neutron_leakage(node, side, xs, invs_dx, g, e++, 0);
+      fill_neutron_balance(M1n_, Q1n_, node, side, xs, d, invs_keff, invs_dx, g,
+                           e++, 0);
 
       // First moment for left node
-      fill_first_moment(node, side, xs, d, invs_keff, invs_dx, g, e++, 0);
+      fill_first_moment(M1n_, Q1n_, node, side, xs, d, invs_keff, invs_dx, g,
+                        e++, 0);
 
       // Second moment for left node
-      fill_second_moment(node, side, xs, d, invs_keff, invs_dx, g, e++, 0);
+      fill_second_moment(M1n_, Q1n_, node, side, xs, d, invs_keff, invs_dx, g,
+                         e++, 0);
 
       // Albedo boundary condition
-      fill_albedo_bc(node[g], xs, invs_dx, side, B, g, e++);
+      fill_albedo_bc(M1n_, Q1n_, node[g], xs, invs_dx, side, B, g, e++);
     }
 
     // Solve system of equations
-    Eigen::BiCGSTAB<Eigen::SparseMatrix<double, Eigen::RowMajor>> solver;
-    solver.setTolerance(1.E-60);
-    solver.compute(M_);
-    auto A = solver.solve(Q_);
+    Solver solver;
+    solver.compute(M1n_);
+    A1n_ = solver.solve(Q1n_);
+    const auto& A = A1n_;
 
     // Compute current and nonlinear diffusion coefficient for each group
+    double max_diff = 0.;
     for (std::size_t g = 0; g < NG_; g++) {
+      const double old_Dnlg = Dnl[g];
+
       const double R = xs.D(g) * invs_dx;
       if (side == Side::XP || side == Side::YP || side == Side::ZP) {
         // See Eq. 22a in [2]
@@ -131,16 +176,48 @@ class NEM4 {
         // See Eq. 2.142 in [2]
         Dnl[g] = -(J + D[g] * node[g].phi0()) / node[g].phi0();
       }
+
+      const double diff = std::abs(Dnl[g] - old_Dnlg);
+      if (diff > max_diff) max_diff = diff;
+
+      // Compute surface flux for side being treated
+      switch (side) {
+        case Side::XN:
+          node[g].phi_xn() =
+              node[g].phi0() + 0.5 * (A(ind(g, 0, 2)) - A(ind(g, 0, 1)));
+          break;
+        case Side::XP:
+          node[g].phi_xp() =
+              node[g].phi0() + 0.5 * (A(ind(g, 0, 1)) + A(ind(g, 0, 2)));
+          break;
+        case Side::YN:
+          node[g].phi_yn() =
+              node[g].phi0() + 0.5 * (A(ind(g, 0, 2)) - A(ind(g, 0, 1)));
+          break;
+        case Side::YP:
+          node[g].phi_yp() =
+              node[g].phi0() + 0.5 * (A(ind(g, 0, 1)) + A(ind(g, 0, 2)));
+          break;
+        case Side::ZN:
+          node[g].phi_zn() =
+              node[g].phi0() + 0.5 * (A(ind(g, 0, 2)) - A(ind(g, 0, 1)));
+          break;
+        case Side::ZP:
+          node[g].phi_zp() =
+              node[g].phi0() + 0.5 * (A(ind(g, 0, 1)) + A(ind(g, 0, 2)));
+          break;
+      }
     }
+    return max_diff;
   }
 
  private:
-  Eigen::SparseMatrix<double, Eigen::RowMajor> M_;
-  Eigen::VectorXd Q_;
+  Matrix M1n_, M2n_;
+  Vector Q1n_, Q2n_, A1n_, A2n_;
   std::size_t NG_;
 
-  int ind(std::size_t g, int n, int a) const {
-    return n * (static_cast<int>(NG_) * 4) + static_cast<int>(g) * 4 + (a - 1);
+  Eigen::Index ind(std::size_t g, std::size_t n, std::size_t a) const {
+    return static_cast<Eigen::Index>(n * (NG_ * 4) + g * 4 + (a - 1));
   }
 
   double get_adf(const Node& n, Side s) const {
@@ -263,143 +340,149 @@ class NEM4 {
     }
   }
 
-  void fill_neutron_balance(std::span<const Node>& node, Side side,
-                            const DiffusionCrossSection& xs,
+  void fill_neutron_balance(Matrix& M, Vector& Q, std::span<const Node> node,
+                            Side side, const DiffusionCrossSection& xs,
                             const std::array<double, 3>& d,
                             const double invs_keff, const double invs_dx,
-                            std::size_t g, const int e, const int n) {
+                            const std::size_t g, const std::size_t e,
+                            const std::size_t n) {
     // Flux balance equation. See Eq. 2.30 in [1]
-    M_.coeffRef(e, ind(g, n, 2)) -= 6. * xs.D(g) * invs_dx * invs_dx;
-    M_.coeffRef(e, ind(g, n, 4)) -= (2. * xs.D(g) / 5.) * invs_dx * invs_dx;
+    M.coeffRef(e, ind(g, n, 2)) -= 6. * xs.D(g) * invs_dx * invs_dx;
+    M.coeffRef(e, ind(g, n, 4)) -= (2. * xs.D(g) / 5.) * invs_dx * invs_dx;
     const double phi_g = node[g].phi0();
-    Q_(e) = -xs.Er(g) * phi_g - get_L(node[g], side, d);
+    Q(e) = -xs.Er(g) * phi_g - get_L(node[g], side, d);
 
     const double chi_g = xs.chi(g);
     for (std::size_t gg = 0; gg < NG_; gg++) {
       const double phi_gg = node[gg].phi0();
-      if (gg != g) Q_(e) += xs.Es(gg, g) * phi_gg;
-      Q_(e) += chi_g * invs_keff * xs.vEf(gg) * phi_gg;
+      if (gg != g) Q(e) += xs.Es(gg, g) * phi_gg;
+      Q(e) += chi_g * invs_keff * xs.vEf(gg) * phi_gg;
     }
   }
 
-  void fill_first_moment(std::span<const Node>& node, Side side,
-                         const DiffusionCrossSection& xs,
+  void fill_first_moment(Matrix& M, Vector& Q, std::span<const Node> node,
+                         Side side, const DiffusionCrossSection& xs,
                          const std::array<double, 3>& d, const double invs_keff,
-                         const double invs_dx, std::size_t g, const int e,
-                         const int n) {
+                         const double invs_dx, const std::size_t g,
+                         const std::size_t e, const std::size_t n) {
     // First residiual moment equation. See Eq. 2.31 in [1]
-    M_.coeffRef(e, ind(g, n, 3)) -= 0.5 * xs.D(g) * invs_dx * invs_dx;
-    M_.coeffRef(e, ind(g, n, 1)) += xs.Er(g) / 12.;
-    M_.coeffRef(e, ind(g, n, 3)) -= xs.Er(g) / 120.;
-    Q_(e) = -get_rho1(node[g], side, d) / 12.;
+    M.coeffRef(e, ind(g, n, 3)) -= 0.5 * xs.D(g) * invs_dx * invs_dx;
+    M.coeffRef(e, ind(g, n, 1)) += xs.Er(g) / 12.;
+    M.coeffRef(e, ind(g, n, 3)) -= xs.Er(g) / 120.;
+    Q(e) = -get_rho1(node[g], side, d) / 12.;
 
     const double chi_g = xs.chi(g);
     for (std::size_t gg = 0; gg < NG_; gg++) {
       if (gg != g) {
-        M_.coeffRef(e, ind(gg, n, 1)) -= xs.Es(gg, g) / 12.;
-        M_.coeffRef(e, ind(gg, n, 3)) += xs.Es(gg, g) / 120.;
+        M.coeffRef(e, ind(gg, n, 1)) -= xs.Es(gg, g) / 12.;
+        M.coeffRef(e, ind(gg, n, 3)) += xs.Es(gg, g) / 120.;
       }
-      M_.coeffRef(e, ind(gg, n, 1)) -= chi_g * invs_keff * xs.vEf(gg) / 12.;
-      M_.coeffRef(e, ind(gg, n, 3)) += chi_g * invs_keff * xs.vEf(gg) / 120.;
+      M.coeffRef(e, ind(gg, n, 1)) -= chi_g * invs_keff * xs.vEf(gg) / 12.;
+      M.coeffRef(e, ind(gg, n, 3)) += chi_g * invs_keff * xs.vEf(gg) / 120.;
     }
   }
 
-  void fill_second_moment(std::span<const Node>& node, Side side,
-                          const DiffusionCrossSection& xs,
+  void fill_second_moment(Matrix& M, Vector& Q, std::span<const Node> node,
+                          Side side, const DiffusionCrossSection& xs,
                           const std::array<double, 3>& d,
                           const double invs_keff, const double invs_dx,
-                          std::size_t g, const int e, const int n) {
+                          const std::size_t g, const std::size_t e,
+                          const std::size_t n) {
     // Second residiual moment equation. See Eq. 2.32 in [1]
-    M_.coeffRef(e, ind(g, n, 4)) -= 0.2 * xs.D(g) * invs_dx * invs_dx;
-    M_.coeffRef(e, ind(g, n, 2)) += xs.Er(g) / 20.;
-    M_.coeffRef(e, ind(g, n, 4)) -= xs.Er(g) / 700.;
-    Q_(e) = -get_rho2(node[g], side, d) / 20.;
+    M.coeffRef(e, ind(g, n, 4)) -= 0.2 * xs.D(g) * invs_dx * invs_dx;
+    M.coeffRef(e, ind(g, n, 2)) += xs.Er(g) / 20.;
+    M.coeffRef(e, ind(g, n, 4)) -= xs.Er(g) / 700.;
+    Q(e) = -get_rho2(node[g], side, d) / 20.;
 
     const double chi_g = xs.chi(g);
     for (std::size_t gg = 0; gg < NG_; gg++) {
       if (gg != g) {
-        M_.coeffRef(e, ind(gg, n, 2)) -= xs.Es(gg, g) / 20.;
-        M_.coeffRef(e, ind(gg, n, 4)) += xs.Es(gg, g) / 700.;
+        M.coeffRef(e, ind(gg, n, 2)) -= xs.Es(gg, g) / 20.;
+        M.coeffRef(e, ind(gg, n, 4)) += xs.Es(gg, g) / 700.;
       }
-      M_.coeffRef(e, ind(gg, n, 2)) -= chi_g * invs_keff * xs.vEf(gg) / 20.;
-      M_.coeffRef(e, ind(gg, n, 4)) += chi_g * invs_keff * xs.vEf(gg) / 700.;
+      M.coeffRef(e, ind(gg, n, 2)) -= chi_g * invs_keff * xs.vEf(gg) / 20.;
+      M.coeffRef(e, ind(gg, n, 4)) += chi_g * invs_keff * xs.vEf(gg) / 700.;
     }
   }
 
-  void fill_flux_discontinuity(const Node& lnode, const Node& rnode, Side side,
-                               std::size_t g, int e) {
+  void fill_flux_discontinuity(Matrix& M, Vector& Q, const Node& lnode,
+                               const Node& rnode, Side side,
+                               const std::size_t g, const std::size_t e) {
     // See Eq. 2.46 in [1]
     const double r = get_op_adf(rnode, side) / get_adf(lnode, side);
 
-    M_.coeffRef(e, ind(g, 0, 1)) += 0.5;
-    M_.coeffRef(e, ind(g, 0, 2)) += 0.5;
+    M.coeffRef(e, ind(g, 0, 1)) += 0.5;
+    M.coeffRef(e, ind(g, 0, 2)) += 0.5;
 
-    M_.coeffRef(e, ind(g, 1, 1)) += 0.5 * r;
-    M_.coeffRef(e, ind(g, 1, 2)) -= 0.5 * r;
+    M.coeffRef(e, ind(g, 1, 1)) += 0.5 * r;
+    M.coeffRef(e, ind(g, 1, 2)) -= 0.5 * r;
 
-    Q_(e) = r * rnode.phi0() - lnode.phi0();
+    Q(e) = r * rnode.phi0() - lnode.phi0();
   }
 
-  void fill_current_continuity(const DiffusionCrossSection& lxs,
+  void fill_current_continuity(Matrix& M, Vector& Q,
+                               const DiffusionCrossSection& lxs,
                                const DiffusionCrossSection& rxs,
                                const double invs_ldx, const double invs_rdx,
-                               std::size_t g, int e) {
+                               const std::size_t g, const std::size_t e) {
     // See Eq. 2.47 in [1]
     const double Rl = lxs.D(g) * invs_ldx;
     const double Rr = rxs.D(g) * invs_rdx;
 
-    M_.coeffRef(e, ind(g, 0, 1)) += Rl;
-    M_.coeffRef(e, ind(g, 0, 2)) += 3. * Rl;
-    M_.coeffRef(e, ind(g, 0, 3)) += 0.5 * Rl;
-    M_.coeffRef(e, ind(g, 0, 4)) += 0.2 * Rl;
+    M.coeffRef(e, ind(g, 0, 1)) += Rl;
+    M.coeffRef(e, ind(g, 0, 2)) += 3. * Rl;
+    M.coeffRef(e, ind(g, 0, 3)) += 0.5 * Rl;
+    M.coeffRef(e, ind(g, 0, 4)) += 0.2 * Rl;
 
-    M_.coeffRef(e, ind(g, 1, 1)) -= Rr;
-    M_.coeffRef(e, ind(g, 1, 2)) += 3. * Rr;
-    M_.coeffRef(e, ind(g, 1, 3)) -= 0.5 * Rr;
-    M_.coeffRef(e, ind(g, 1, 4)) += 0.2 * Rr;
+    M.coeffRef(e, ind(g, 1, 1)) -= Rr;
+    M.coeffRef(e, ind(g, 1, 2)) += 3. * Rr;
+    M.coeffRef(e, ind(g, 1, 3)) -= 0.5 * Rr;
+    M.coeffRef(e, ind(g, 1, 4)) += 0.2 * Rr;
 
-    Q_(e) = 0.;
+    Q(e) = 0.;
   }
 
-  void fill_albedo_bc(const Node& node, const DiffusionCrossSection& xs,
-                      const double invs_dx, Side side, const double B,
-                      std::size_t g, int e) {
+  void fill_albedo_bc(Matrix& M, Vector& Q, const Node& node,
+                      const DiffusionCrossSection& xs, const double invs_dx,
+                      Side side, const double B, const std::size_t g,
+                      const std::size_t e) {
     const double D = xs.D(g);
     const double R = D * invs_dx;
     const double G = 0.5 * ((1. - B) / (1. + B));
     if (side == Side::XP || side == Side::YP || side == Side::ZP) {
-      /*
-      // See Eq. 22a in [2]
-      M_.coeffRef(e, ind(g, 0, 1)) = -R;
-      M_.coeffRef(e, ind(g, 0, 2)) = -3. * R;
-      M_.coeffRef(e, ind(g, 0, 3)) = -0.5 * R;
-      M_.coeffRef(e, ind(g, 0, 4)) = -0.2 * R;
-      Q_(e) = 1. - B;
-      */
-
       // See Eq. 2.55 in [1]
-      M_.coeffRef(e, ind(g, 0, 1)) = 0.5 * G + R;
-      M_.coeffRef(e, ind(g, 0, 2)) = 0.5 * G + 3. * R;
-      M_.coeffRef(e, ind(g, 0, 3)) = 0.5 * R;
-      M_.coeffRef(e, ind(g, 0, 4)) = 0.2 * R;
-      Q_(e) = -G * node.phi0();
+      M.coeffRef(e, ind(g, 0, 1)) = 0.5 * G + R;
+      M.coeffRef(e, ind(g, 0, 2)) = 0.5 * G + 3. * R;
+      M.coeffRef(e, ind(g, 0, 3)) = 0.5 * R;
+      M.coeffRef(e, ind(g, 0, 4)) = 0.2 * R;
+      Q(e) = -G * node.phi0();
     } else {
-      /*
-      // See Eq. 22b in [2]
-      M_.coeffRef(e, ind(g, 0, 1)) = R;
-      M_.coeffRef(e, ind(g, 0, 2)) = -3. * R;
-      M_.coeffRef(e, ind(g, 0, 3)) = 0.5 * R;
-      M_.coeffRef(e, ind(g, 0, 4)) = -0.2 * R;
-      Q_(e) = 1. - B;
-      */
-
       // See Eq. 2.54 in [1]
-      M_.coeffRef(e, ind(g, 0, 1)) = -(0.5 * G + R);
-      M_.coeffRef(e, ind(g, 0, 2)) = 0.5 * G + 3. * R;
-      M_.coeffRef(e, ind(g, 0, 3)) = -0.5 * R;
-      M_.coeffRef(e, ind(g, 0, 4)) = 0.2 * R;
-      Q_(e) = -G * node.phi0();
+      M.coeffRef(e, ind(g, 0, 1)) = -(0.5 * G + R);
+      M.coeffRef(e, ind(g, 0, 2)) = 0.5 * G + 3. * R;
+      M.coeffRef(e, ind(g, 0, 3)) = -0.5 * R;
+      M.coeffRef(e, ind(g, 0, 4)) = 0.2 * R;
+      Q(e) = -G * node.phi0();
     }
+  }
+
+  friend class cereal::access;
+  NEM4() = default;
+
+  template <class Archive>
+  void save(Archive& arc) const {
+    arc(NG_);
+  }
+
+  template <class Archive>
+  void load(Archive& arc) {
+    arc(NG_);
+    M1n_.resize(4 * NG_, 4 * NG_);
+    M2n_.resize(8 * NG_, 8 * NG_);
+    Q1n_.resize(4 * NG_);
+    Q2n_.resize(8 * NG_);
+    A1n_.resize(4 * NG_);
+    A2n_.resize(8 * NG_);
   }
 };
 

--- a/src/scarabee/_scarabee/include/diffusion/nem4.hpp
+++ b/src/scarabee/_scarabee/include/diffusion/nem4.hpp
@@ -1,0 +1,414 @@
+#ifndef SCARABEE_NEM4_H
+#define SCARABEE_NEM4_H
+
+#include <diffusion/nodal_method.hpp>
+#include <data/diffusion_cross_section.hpp>
+
+#include <Eigen/Sparse>
+
+#include <array>
+#include <cstddef>
+#include <span>
+
+namespace scarabee {
+
+class NEM4 {
+ public:
+  NEM4(std::size_t NG) : M_{}, Q_{}, NG_{NG} {
+    M_.resize(8 * NG, 8 * NG);
+    Q_.resize(8 * NG);
+  }
+
+  static constexpr bool update_currents{true};
+
+  void compute_keff_nonlinear_diffusion_coefficient(
+      std::span<const Node> lnode, const Side side, std::span<const Node> rnode,
+      std::span<const double> D, const DiffusionCrossSection& lxs,
+      const DiffusionCrossSection& rxs, const std::array<double, 3> ld,
+      const std::array<double, 3> rd, std::span<double> Dnl,
+      const double invs_keff) {
+    const double invs_ldx = 1. / get_node_width(ld, side);
+    const double invs_rdx = 1. / get_node_width(rd, side);
+
+    M_.resize(8 * NG_, 8 * NG_);
+    M_.setZero();
+    Q_.resize(8 * NG_);
+    Q_.setZero();
+
+    // We have 8 equations for each energy group
+    int e = 0;
+    for (std::size_t g = 0; g < NG_; g++) {
+      // Flux balance equation for left node
+      fill_neutron_balance(lnode, side, lxs, ld, invs_keff, invs_ldx, g, e++,
+                           0);
+      // fill_neutron_leakage(lnode, side, lxs, invs_ldx, g, e++, 0);
+      //  Flux balance equation for right node
+      fill_neutron_balance(rnode, side, rxs, rd, invs_keff, invs_rdx, g, e++,
+                           1);
+      // fill_neutron_leakage(rnode, side, rxs, invs_rdx, g, e++, 1);
+
+      // First moment for left node
+      fill_first_moment(lnode, side, lxs, ld, invs_keff, invs_ldx, g, e++, 0);
+      // First moment for right node
+      fill_first_moment(rnode, side, rxs, rd, invs_keff, invs_rdx, g, e++, 1);
+
+      // Second moment for left node
+      fill_second_moment(lnode, side, lxs, ld, invs_keff, invs_ldx, g, e++, 0);
+      // Second moment for right node
+      fill_second_moment(rnode, side, rxs, rd, invs_keff, invs_rdx, g, e++, 1);
+
+      // Flux (dis)continuity condition
+      fill_flux_discontinuity(lnode[g], rnode[g], side, g, e++);
+
+      // Current continuity condition
+      fill_current_continuity(lxs, rxs, invs_ldx, invs_rdx, g, e++);
+    }
+
+    // Solve system of equations
+    Eigen::BiCGSTAB<Eigen::SparseMatrix<double, Eigen::RowMajor>> solver;
+    solver.setTolerance(1.E-60);
+    solver.compute(M_);
+    auto A = solver.solve(Q_);
+
+    // Compute current and nonlinear diffusion coefficient for each group
+    for (std::size_t g = 0; g < NG_; g++) {
+      const double J = -lxs.D(g) * invs_ldx *
+                       (A(ind(g, 0, 1)) + 3. * A(ind(g, 0, 2)) +
+                        0.5 * A(ind(g, 0, 3)) + 0.2 * A(ind(g, 0, 4)));
+      const double phi_i = lnode[g].phi0();
+      const double phi_i1 = rnode[g].phi0();
+
+      Dnl[g] = -(J + D[g] * (phi_i1 - phi_i)) / (phi_i1 + phi_i);
+    }
+  }
+
+  void compute_keff_nonlinear_diffusion_coefficient(
+      std::span<const Node> node, const Side side, std::span<const double> D,
+      double B, const DiffusionCrossSection& xs, const std::array<double, 3> d,
+      std::span<double> Dnl, const double invs_keff) {
+    const double invs_dx = 1. / get_node_width(d, side);
+    M_.resize(4 * NG_, 4 * NG_);
+    M_.setZero();
+    Q_.resize(4 * NG_);
+    Q_.setZero();
+
+    // We have 8 equations for each energy group
+    int e = 0;
+    for (std::size_t g = 0; g < NG_; g++) {
+      // Flux balance equation
+      fill_neutron_balance(node, side, xs, d, invs_keff, invs_dx, g, e++, 0);
+      // fill_neutron_leakage(node, side, xs, invs_dx, g, e++, 0);
+
+      // First moment for left node
+      fill_first_moment(node, side, xs, d, invs_keff, invs_dx, g, e++, 0);
+
+      // Second moment for left node
+      fill_second_moment(node, side, xs, d, invs_keff, invs_dx, g, e++, 0);
+
+      // Albedo boundary condition
+      fill_albedo_bc(node[g], xs, invs_dx, side, B, g, e++);
+    }
+
+    // Solve system of equations
+    Eigen::BiCGSTAB<Eigen::SparseMatrix<double, Eigen::RowMajor>> solver;
+    solver.setTolerance(1.E-60);
+    solver.compute(M_);
+    auto A = solver.solve(Q_);
+
+    // Compute current and nonlinear diffusion coefficient for each group
+    for (std::size_t g = 0; g < NG_; g++) {
+      const double R = xs.D(g) * invs_dx;
+      if (side == Side::XP || side == Side::YP || side == Side::ZP) {
+        // See Eq. 22a in [2]
+        const double J = -R * (A(ind(g, 0, 1)) + 3. * A(ind(g, 0, 2)) +
+                               0.5 * A(ind(g, 0, 3)) + 0.2 * A(ind(g, 0, 4)));
+        // See Eq. 2.141 in [1]
+        Dnl[g] = -(J - D[g] * node[g].phi0()) / node[g].phi0();
+      } else {
+        // See Eq. 22b in [2]
+        const double J = -R * (A(ind(g, 0, 1)) - 3. * A(ind(g, 0, 2)) +
+                               0.5 * A(ind(g, 0, 3)) - 0.2 * A(ind(g, 0, 4)));
+        // See Eq. 2.142 in [2]
+        Dnl[g] = -(J + D[g] * node[g].phi0()) / node[g].phi0();
+      }
+    }
+  }
+
+ private:
+  Eigen::SparseMatrix<double, Eigen::RowMajor> M_;
+  Eigen::VectorXd Q_;
+  std::size_t NG_;
+
+  int ind(std::size_t g, int n, int a) const {
+    return n * (static_cast<int>(NG_) * 4) + static_cast<int>(g) * 4 + (a - 1);
+  }
+
+  double get_adf(const Node& n, Side s) const {
+    switch (s) {
+      case Side::XN:
+        return n.adf_xn();
+      case Side::XP:
+        return n.adf_xp();
+      case Side::YN:
+        return n.adf_yn();
+      case Side::YP:
+        return n.adf_yp();
+      case Side::ZN:
+        return n.adf_zn();
+      case Side::ZP:
+        return n.adf_zp();
+      default:
+        return 1;  // Should never get here
+    }
+  }
+
+  double get_op_adf(const Node& n, Side s) const {
+    switch (s) {
+      case Side::XN:
+        return n.adf_xp();
+      case Side::XP:
+        return n.adf_xn();
+      case Side::YN:
+        return n.adf_yp();
+      case Side::YP:
+        return n.adf_yn();
+      case Side::ZN:
+        return n.adf_zp();
+      case Side::ZP:
+        return n.adf_zn();
+      default:
+        return 1.;  // Should never get here
+    }
+  }
+
+  double get_node_width(const std::array<double, 3>& dx, Side side) const {
+    switch (side) {
+      case Side::XP:
+      case Side::XN:
+        return dx[0];
+      case Side::YP:
+      case Side::YN:
+        return dx[1];
+      case Side::ZP:
+      case Side::ZN:
+        return dx[2];
+      default:
+        return dx[0];  // Should never get here !
+    }
+  }
+
+  double get_L(const Node& node, const Side side,
+               const std::array<double, 3>& d) {
+    switch (side) {
+      case Side::XP:
+      case Side::XN: {
+        const double Ly = node.J_yp() - node.J_yn();
+        const double Lz = node.J_zp() - node.J_zn();
+        return (Ly / d[1]) + (Lz / d[2]);
+      }
+      case Side::YP:
+      case Side::YN: {
+        const double Lx = node.J_xp() - node.J_xn();
+        const double Lz = node.J_zp() - node.J_zn();
+        return (Lx / d[0]) + (Lz / d[2]);
+      }
+      case Side::ZP:
+      case Side::ZN: {
+        const double Lx = node.J_xp() - node.J_xn();
+        const double Ly = node.J_yp() - node.J_yn();
+        return (Lx / d[0]) + (Ly / d[1]);
+      }
+      default:
+        return 0.;
+    }
+  }
+
+  double get_rho1(const Node& node, const Side side,
+                  const std::array<double, 3>& d) {
+    switch (side) {
+      case Side::XP:
+      case Side::XN: {
+        return node.Lx_rho_y1() / d[1] + node.Lx_rho_z1() / d[2];
+      }
+      case Side::YP:
+      case Side::YN: {
+        return node.Ly_rho_x1() / d[0] + node.Ly_rho_z1() / d[2];
+      }
+      case Side::ZP:
+      case Side::ZN: {
+        return node.Lz_rho_x1() / d[0] + node.Lz_rho_y1() / d[1];
+      }
+      default:
+        return 0.;
+    }
+  }
+
+  double get_rho2(const Node& node, const Side side,
+                  const std::array<double, 3>& d) {
+    switch (side) {
+      case Side::XP:
+      case Side::XN: {
+        return node.Lx_rho_y2() / d[1] + node.Lx_rho_z2() / d[2];
+      }
+      case Side::YP:
+      case Side::YN: {
+        return node.Ly_rho_x2() / d[0] + node.Ly_rho_z2() / d[2];
+      }
+      case Side::ZP:
+      case Side::ZN: {
+        return node.Lz_rho_x2() / d[0] + node.Lz_rho_y2() / d[1];
+      }
+      default:
+        return 0.;
+    }
+  }
+
+  void fill_neutron_balance(std::span<const Node>& node, Side side,
+                            const DiffusionCrossSection& xs,
+                            const std::array<double, 3>& d,
+                            const double invs_keff, const double invs_dx,
+                            std::size_t g, const int e, const int n) {
+    // Flux balance equation. See Eq. 2.30 in [1]
+    M_.coeffRef(e, ind(g, n, 2)) -= 6. * xs.D(g) * invs_dx * invs_dx;
+    M_.coeffRef(e, ind(g, n, 4)) -= (2. * xs.D(g) / 5.) * invs_dx * invs_dx;
+    const double phi_g = node[g].phi0();
+    Q_(e) = -xs.Er(g) * phi_g - get_L(node[g], side, d);
+
+    const double chi_g = xs.chi(g);
+    for (std::size_t gg = 0; gg < NG_; gg++) {
+      const double phi_gg = node[gg].phi0();
+      if (gg != g) Q_(e) += xs.Es(gg, g) * phi_gg;
+      Q_(e) += chi_g * invs_keff * xs.vEf(gg) * phi_gg;
+    }
+  }
+
+  void fill_first_moment(std::span<const Node>& node, Side side,
+                         const DiffusionCrossSection& xs,
+                         const std::array<double, 3>& d, const double invs_keff,
+                         const double invs_dx, std::size_t g, const int e,
+                         const int n) {
+    // First residiual moment equation. See Eq. 2.31 in [1]
+    M_.coeffRef(e, ind(g, n, 3)) -= 0.5 * xs.D(g) * invs_dx * invs_dx;
+    M_.coeffRef(e, ind(g, n, 1)) += xs.Er(g) / 12.;
+    M_.coeffRef(e, ind(g, n, 3)) -= xs.Er(g) / 120.;
+    Q_(e) = -get_rho1(node[g], side, d) / 12.;
+
+    const double chi_g = xs.chi(g);
+    for (std::size_t gg = 0; gg < NG_; gg++) {
+      if (gg != g) {
+        M_.coeffRef(e, ind(gg, n, 1)) -= xs.Es(gg, g) / 12.;
+        M_.coeffRef(e, ind(gg, n, 3)) += xs.Es(gg, g) / 120.;
+      }
+      M_.coeffRef(e, ind(gg, n, 1)) -= chi_g * invs_keff * xs.vEf(gg) / 12.;
+      M_.coeffRef(e, ind(gg, n, 3)) += chi_g * invs_keff * xs.vEf(gg) / 120.;
+    }
+  }
+
+  void fill_second_moment(std::span<const Node>& node, Side side,
+                          const DiffusionCrossSection& xs,
+                          const std::array<double, 3>& d,
+                          const double invs_keff, const double invs_dx,
+                          std::size_t g, const int e, const int n) {
+    // Second residiual moment equation. See Eq. 2.32 in [1]
+    M_.coeffRef(e, ind(g, n, 4)) -= 0.2 * xs.D(g) * invs_dx * invs_dx;
+    M_.coeffRef(e, ind(g, n, 2)) += xs.Er(g) / 20.;
+    M_.coeffRef(e, ind(g, n, 4)) -= xs.Er(g) / 700.;
+    Q_(e) = -get_rho2(node[g], side, d) / 20.;
+
+    const double chi_g = xs.chi(g);
+    for (std::size_t gg = 0; gg < NG_; gg++) {
+      if (gg != g) {
+        M_.coeffRef(e, ind(gg, n, 2)) -= xs.Es(gg, g) / 20.;
+        M_.coeffRef(e, ind(gg, n, 4)) += xs.Es(gg, g) / 700.;
+      }
+      M_.coeffRef(e, ind(gg, n, 2)) -= chi_g * invs_keff * xs.vEf(gg) / 20.;
+      M_.coeffRef(e, ind(gg, n, 4)) += chi_g * invs_keff * xs.vEf(gg) / 700.;
+    }
+  }
+
+  void fill_flux_discontinuity(const Node& lnode, const Node& rnode, Side side,
+                               std::size_t g, int e) {
+    // See Eq. 2.46 in [1]
+    const double r = get_op_adf(rnode, side) / get_adf(lnode, side);
+
+    M_.coeffRef(e, ind(g, 0, 1)) += 0.5;
+    M_.coeffRef(e, ind(g, 0, 2)) += 0.5;
+
+    M_.coeffRef(e, ind(g, 1, 1)) += 0.5 * r;
+    M_.coeffRef(e, ind(g, 1, 2)) -= 0.5 * r;
+
+    Q_(e) = r * rnode.phi0() - lnode.phi0();
+  }
+
+  void fill_current_continuity(const DiffusionCrossSection& lxs,
+                               const DiffusionCrossSection& rxs,
+                               const double invs_ldx, const double invs_rdx,
+                               std::size_t g, int e) {
+    // See Eq. 2.47 in [1]
+    const double Rl = lxs.D(g) * invs_ldx;
+    const double Rr = rxs.D(g) * invs_rdx;
+
+    M_.coeffRef(e, ind(g, 0, 1)) += Rl;
+    M_.coeffRef(e, ind(g, 0, 2)) += 3. * Rl;
+    M_.coeffRef(e, ind(g, 0, 3)) += 0.5 * Rl;
+    M_.coeffRef(e, ind(g, 0, 4)) += 0.2 * Rl;
+
+    M_.coeffRef(e, ind(g, 1, 1)) -= Rr;
+    M_.coeffRef(e, ind(g, 1, 2)) += 3. * Rr;
+    M_.coeffRef(e, ind(g, 1, 3)) -= 0.5 * Rr;
+    M_.coeffRef(e, ind(g, 1, 4)) += 0.2 * Rr;
+
+    Q_(e) = 0.;
+  }
+
+  void fill_albedo_bc(const Node& node, const DiffusionCrossSection& xs,
+                      const double invs_dx, Side side, const double B,
+                      std::size_t g, int e) {
+    const double D = xs.D(g);
+    const double R = D * invs_dx;
+    const double G = 0.5 * ((1. - B) / (1. + B));
+    if (side == Side::XP || side == Side::YP || side == Side::ZP) {
+      /*
+      // See Eq. 22a in [2]
+      M_.coeffRef(e, ind(g, 0, 1)) = -R;
+      M_.coeffRef(e, ind(g, 0, 2)) = -3. * R;
+      M_.coeffRef(e, ind(g, 0, 3)) = -0.5 * R;
+      M_.coeffRef(e, ind(g, 0, 4)) = -0.2 * R;
+      Q_(e) = 1. - B;
+      */
+
+      // See Eq. 2.55 in [1]
+      M_.coeffRef(e, ind(g, 0, 1)) = 0.5 * G + R;
+      M_.coeffRef(e, ind(g, 0, 2)) = 0.5 * G + 3. * R;
+      M_.coeffRef(e, ind(g, 0, 3)) = 0.5 * R;
+      M_.coeffRef(e, ind(g, 0, 4)) = 0.2 * R;
+      Q_(e) = -G * node.phi0();
+    } else {
+      /*
+      // See Eq. 22b in [2]
+      M_.coeffRef(e, ind(g, 0, 1)) = R;
+      M_.coeffRef(e, ind(g, 0, 2)) = -3. * R;
+      M_.coeffRef(e, ind(g, 0, 3)) = 0.5 * R;
+      M_.coeffRef(e, ind(g, 0, 4)) = -0.2 * R;
+      Q_(e) = 1. - B;
+      */
+
+      // See Eq. 2.54 in [1]
+      M_.coeffRef(e, ind(g, 0, 1)) = -(0.5 * G + R);
+      M_.coeffRef(e, ind(g, 0, 2)) = 0.5 * G + 3. * R;
+      M_.coeffRef(e, ind(g, 0, 3)) = -0.5 * R;
+      M_.coeffRef(e, ind(g, 0, 4)) = 0.2 * R;
+      Q_(e) = -G * node.phi0();
+    }
+  }
+};
+
+}  // namespace scarabee
+
+// [1] A. Hébert, "The BRISINGR Theory and User Guide", IGE-380
+//
+// [2] R. D. Lawrence, “Progress in nodal methods for the solution of the
+//     neutron diffusion and transport equations,” Prog Nucl Energ, vol. 17,
+//     no. 3, pp. 271–301, 1986, doi: 10.1016/0149-1970(86)90034-x.
+
+#endif

--- a/src/scarabee/_scarabee/include/diffusion/nodal_cmfd_surface.hpp
+++ b/src/scarabee/_scarabee/include/diffusion/nodal_cmfd_surface.hpp
@@ -5,6 +5,9 @@
 #include <utils/logging.hpp>
 #include <utils/scarabee_exception.hpp>
 
+#include <cereal/cereal.hpp>
+#include <cereal/types/optional.hpp>
+
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
@@ -24,6 +27,9 @@ inline void hash_combine(std::uint64_t& s, const T& v) {
 using Side = DiffusionGeometry::Neighbor;  // Index to side of node
 
 struct NodalCMFDSurface {
+  // Default constructor needs to be public for cereal
+  NodalCMFDSurface() : node1(0), side(Side::XN), node2(std::nullopt) {}
+
   NodalCMFDSurface(std::size_t n1, Side s, std::size_t n2)
       : node1(n1), side(s), node2(n2) {
     // Make sure node1 is always on the - side, and node2 is always on the +
@@ -88,6 +94,13 @@ struct NodalCMFDSurface {
   std::size_t node1;
   Side side;
   std::optional<std::size_t> node2;
+
+ private:
+  friend class cereal::access;
+  template <class Archive>
+  void serialize(Archive& arc) {
+    arc(CEREAL_NVP(node1), CEREAL_NVP(side), CEREAL_NVP(node2));
+  }
 };
 
 }  // namespace scarabee

--- a/src/scarabee/_scarabee/include/diffusion/nodal_cmfd_surface.hpp
+++ b/src/scarabee/_scarabee/include/diffusion/nodal_cmfd_surface.hpp
@@ -1,0 +1,109 @@
+#ifndef SCARABEE_NODAL_CMFD_SURFACE_H
+#define SCARABEE_NODAL_CMFD_SURFACE_H
+
+#include <diffusion/diffusion_geometry.hpp>
+#include <utils/logging.hpp>
+#include <utils/scarabee_exception.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <compare>
+#include <optional>
+
+namespace scarabee {
+
+namespace detail {
+template <class T>
+inline void hash_combine(std::uint64_t& s, const T& v) {
+  std::hash<T> h;
+  s ^= h(v) + 0x9e3779b9 + (s << 6) + (s >> 2);
+}
+}  // namespace detail
+
+using Side = DiffusionGeometry::Neighbor;  // Index to side of node
+
+struct NodalCMFDSurface {
+  NodalCMFDSurface(std::size_t n1, Side s, std::size_t n2)
+      : node1(n1), side(s), node2(n2) {
+    // Make sure node1 is always on the - side, and node2 is always on the +
+    // side ! We do this by swapping if s is a negative side.
+    switch (s) {
+      case Side::XN:
+        std::swap(n1, n2);
+        s = Side::XP;
+        break;
+      case Side::YN:
+        std::swap(n1, n2);
+        s = Side::YP;
+        break;
+      case Side::ZN:
+        std::swap(n1, n2);
+        s = Side::ZP;
+        break;
+      default:
+        break;
+    }
+
+    if (n1 == n2) {
+      // Apparently, n1 = n2, which does not define a side !
+      const auto mssg = "Node1 and Node2 cannot be equal.";
+      spdlog::error(mssg);
+      throw ScarabeeException(mssg);
+    }
+
+    node1 = n1;
+    node2 = n2;
+    side = s;
+  }
+  NodalCMFDSurface(std::size_t n1, Side s)
+      : node1(n1), side(s), node2(std::nullopt) {}
+
+  std::strong_ordering operator<=>(const NodalCMFDSurface& other) const {
+    if (this->node1 < other.node1)
+      return std::strong_ordering::less;
+    else if (this->node1 > other.node1)
+      return std::strong_ordering::greater;
+
+    if (this->node2 && other.node2 == false)
+      return std::strong_ordering::less;
+    else if (this->node2 == false && other.node2)
+      return std::strong_ordering::greater;
+    else if (this->node2 && other.node2) {
+      if (this->node2.value() < other.node2.value())
+        return std::strong_ordering::less;
+      else if (this->node2.value() > other.node2.value())
+        return std::strong_ordering::greater;
+    }
+    return std::strong_ordering::equal;
+  }
+
+  bool operator<(const NodalCMFDSurface& other) const = default;
+  bool operator<=(const NodalCMFDSurface& other) const = default;
+  bool operator==(const NodalCMFDSurface& other) const = default;
+  bool operator!=(const NodalCMFDSurface& other) const = default;
+  bool operator>=(const NodalCMFDSurface& other) const = default;
+  bool operator>(const NodalCMFDSurface& other) const = default;
+
+  std::size_t node1;
+  Side side;
+  std::optional<std::size_t> node2;
+};
+
+}  // namespace scarabee
+
+namespace std {
+template <>
+class hash<scarabee::NodalCMFDSurface> {
+ public:
+  std::uint64_t operator()(const scarabee::NodalCMFDSurface& s) const {
+    std::uint64_t res = 0;
+    ::scarabee::detail::hash_combine(res, s.node1);
+    ::scarabee::detail::hash_combine(res, s.side);
+    ::scarabee::detail::hash_combine(res, s.node2);
+    return res;
+  }
+};
+}  // namespace std
+
+#endif

--- a/src/scarabee/_scarabee/include/diffusion/nodal_diffusion_driver.hpp
+++ b/src/scarabee/_scarabee/include/diffusion/nodal_diffusion_driver.hpp
@@ -1040,9 +1040,9 @@ void NodalDiffusionDriver<NM>::solve_keff() {
     spdlog::info("     keff difference:     {:.5E}", keff_diff);
     spdlog::info("     max flux difference: {:.5E}", flux_diff);
 
-    if (iteration % nonlinear_update_frequency_ == 0 ||
-        (flux_diff < flux_tol_ && D_diff > Dnl_tol_)) {
-      flux_diff = 1.;  // Make sure we do at least one iteration after update
+    if ((iteration % nonlinear_update_frequency_ == 0 ||
+         (flux_diff < flux_tol_ && D_diff > Dnl_tol_)) &&
+        (keff_diff > keff_tol_ || flux_diff > flux_tol_ || D_diff > Dnl_tol_)) {
       spdlog::info("-------------------------------------");
       spdlog::info("");
       spdlog::info("Updating nonlinear diffusion coefficients");

--- a/src/scarabee/_scarabee/include/diffusion/nodal_diffusion_driver.hpp
+++ b/src/scarabee/_scarabee/include/diffusion/nodal_diffusion_driver.hpp
@@ -8,17 +8,27 @@
 #include <diffusion/node.hpp>
 #include <diffusion/nodal_cmfd_surface.hpp>
 #include <diffusion/nodal_method.hpp>
+#include <utils/serialization.hpp>
 #include <utils/logging.hpp>
 #include <utils/scarabee_exception.hpp>
+#include <utils/timer.hpp>
 
 #include <xtensor/containers/xtensor.hpp>
 
+#include <Eigen/Dense>
 #include <Eigen/Sparse>
 #include <Eigen/IterativeLinearSolvers>
 
-#include <Eigen/SparseLU>
+#include <cereal/cereal.hpp>
+#include <cereal/types/memory.hpp>
+#include <cereal/types/vector.hpp>
+#include <cereal/types/unordered_map.hpp>
+#include <cereal/types/utility.hpp>
+#include <cereal/archives/portable_binary.hpp>
 
 #include <cstddef>
+#include <filesystem>
+#include <fstream>
 #include <memory>
 #include <optional>
 #include <span>
@@ -29,6 +39,10 @@ namespace scarabee {
 
 template <NodalMethod NM>
 class NodalDiffusionDriver {
+  using Vector = Eigen::VectorXd;
+  using Matrix = Eigen::SparseMatrix<double, Eigen::RowMajor>;
+  using Solver = Eigen::BiCGSTAB<Matrix, Eigen::IdentityPreconditioner>;
+
  public:
   NodalDiffusionDriver(std::shared_ptr<DiffusionGeometry> geom);
 
@@ -45,17 +59,32 @@ class NodalDiffusionDriver {
   double flux_tolerance() const { return flux_tol_; }
   void set_flux_tolerance(double ftol);
 
-  bool leakage_corrections() const { return leakage_corrections_; }
-  void set_leakage_corrections(bool lc) { leakage_corrections_ = lc; }
+  bool leakage_corrections() const
+    requires(NM::update_currents)
+  {
+    return leakage_corrections_;
+  }
+  void set_leakage_corrections(bool lc)
+    requires(NM::update_currents)
+  {
+    leakage_corrections_ = lc;
+  }
 
   std::size_t nonlinear_update_frequency() const {
     return nonlinear_update_frequency_;
   }
   void set_nonlinear_update_frequency(std::size_t f);
 
+  std::size_t source_extrapolation_frequency() const {
+    return source_extrapolation_frequency_;
+  }
+  void set_source_extrapolation_frequency(std::size_t f);
+
+  std::size_t max_inner_iterations() const { return max_bicgstab_iterations_; }
+  void set_max_inner_iterations(std::size_t n);
+
   double keff() const { return keff_; }
 
-  /*
   double flux(double x, double y, double z, std::size_t g) const;
   xt::xtensor<double, 4> flux(const xt::xtensor<double, 1>& x,
                               const xt::xtensor<double, 1>& y,
@@ -70,7 +99,6 @@ class NodalDiffusionDriver {
 
   void save(const std::string& fname);
   static std::unique_ptr<NodalDiffusionDriver> load(const std::string& fname);
-  */
 
  private:
   struct DiffusionDataCrossSectionPair {
@@ -78,29 +106,45 @@ class NodalDiffusionDriver {
         const std::shared_ptr<DiffusionData>& idd,
         const std::shared_ptr<DiffusionCrossSection>& ixs)
         : dd(idd), xs(ixs) {}
+    DiffusionDataCrossSectionPair() : dd(nullptr), xs(nullptr) {}
 
     std::shared_ptr<DiffusionData> dd;
     std::shared_ptr<DiffusionCrossSection>
         xs;  // Might be different from xs in dd !!
+
+    template <class Archive>
+    void serialize(Archive& arc) {
+      arc(CEREAL_NVP(dd), CEREAL_NVP(xs));
+    }
   };
+
   using NeighborInfo =
       std::pair<DiffusionGeometry::Tile, std::optional<std::size_t>>;
+
+  enum class Corner { PP, PM, MP, MM };
 
  private:
   // Method relating to solve
   void update_adfs();
   void update_physical_diffusion_coefficients();
-  void update_nonlinear_diffusion_coefficients();
+  double update_nonlinear_diffusion_coefficients();
+
   template <typename DiffCoeffUpdater>
-  void update_diffusion_coefficients(DiffCoeffUpdater dcu);
-  void update_fluxes(Eigen::VectorXd& flux);
+  double update_diffusion_coefficients(DiffCoeffUpdater dcu);
+
+  void update_fluxes(const Vector& flux);
   void update_currents();
   void update_transverse_leakage_coefficients();
 
   void solve_keff();
-  void fill_loss_matrix(Eigen::SparseMatrix<double, Eigen::RowMajor>& M) const;
-  void fill_fission_matrix(
-      Eigen::SparseMatrix<double, Eigen::RowMajor>& F) const;
+  void fill_loss_matrix(Matrix& M) const;
+  void fill_fission_matrix(Matrix& F) const;
+
+  double calc_node_avg_DB2(const std::size_t g, const std::size_t m,
+                           const double dx, const double dy,
+                           const double dz) const;
+  void update_node_xs()
+    requires(NM::update_currents);
 
   // To get index in nodal solver
   int ind(std::size_t n, std::size_t g) const {
@@ -125,6 +169,16 @@ class NodalDiffusionDriver {
   };
 
   // Reconstruction related methods
+  void perform_flux_reconstruction()
+    requires(NM::reconstruct_flux);
+  IntraNodalFlux fit_node_recon_params(std::size_t g, std::size_t m) const
+    requires(NM::reconstruct_flux);
+  void fit_node_recon_params_corners(std::size_t g, std::size_t m)
+    requires(NM::reconstruct_flux);
+  double eval_heter_xy_corner_flux(std::size_t g, std::size_t m, Corner c) const
+    requires(NM::reconstruct_flux);
+  double avg_xy_corner_flux(std::size_t g, std::size_t m, Corner c) const
+    requires(NM::reconstruct_flux);
 
  private:
   xt::xtensor<Node, 2> nodes_;  // Node THEN Group ! Must be to make span
@@ -144,23 +198,42 @@ class NodalDiffusionDriver {
   xt::xtensor<double, 3> surface_diffusion_coefficients_;
 
   // Holds average flux between iterations
-  Eigen::VectorXd flux_;
+  Vector flux_;
 
   std::shared_ptr<DiffusionGeometry> geom_;
-  std::size_t NG_;  // Number of groups
-  std::size_t NM_;  // Number of regions
-  std::size_t nonlinear_update_frequency_{20};
+  std::size_t NG_;                          // Number of groups
+  std::size_t NM_;                          // Number of regions
+  std::size_t nonlinear_update_frequency_;  // Set in constructor based on NM_
+  std::size_t source_extrapolation_frequency_{5};
+  std::size_t max_bicgstab_iterations_{2};
   double keff_{1.};
   double flux_tol_{1.E-5};
   double keff_tol_{1.E-5};
+  double Dnl_tol_{1.E-3};
   bool leakage_corrections_{false};
   bool solved_{false};
+
+  friend class cereal::access;
+  NodalDiffusionDriver() : nodal_solver_(2) {}
+  template <class Archive>
+  void serialize(Archive& arc) {
+    arc(CEREAL_NVP(nodes_), CEREAL_NVP(reconstructed_flux_params_),
+        CEREAL_NVP(nodal_solver_), CEREAL_NVP(neighbors_), CEREAL_NVP(mats_),
+        CEREAL_NVP(surface_indices_),
+        CEREAL_NVP(surface_diffusion_coefficients_), CEREAL_NVP(flux_),
+        CEREAL_NVP(geom_), CEREAL_NVP(NG_), CEREAL_NVP(NM_),
+        CEREAL_NVP(nonlinear_update_frequency_),
+        CEREAL_NVP(source_extrapolation_frequency_),
+        CEREAL_NVP(max_bicgstab_iterations_), CEREAL_NVP(keff_),
+        CEREAL_NVP(flux_tol_), CEREAL_NVP(keff_tol_), CEREAL_NVP(Dnl_tol_),
+        CEREAL_NVP(leakage_corrections_), CEREAL_NVP(solved_));
+  }
 };
 
 template <NodalMethod NM>
 inline NodalDiffusionDriver<NM>::NodalDiffusionDriver(
     std::shared_ptr<DiffusionGeometry> geom)
-    : nodal_solver_(0), geom_(geom) {
+    : nodal_solver_(2), geom_(geom) {
   if (geom_ == nullptr) {
     const auto mssg = "Provided geometry was None.";
     spdlog::error(mssg);
@@ -175,12 +248,27 @@ inline NodalDiffusionDriver<NM>::NodalDiffusionDriver(
   NG_ = geom_->ngroups();
   NM_ = geom_->nmats();
 
-  // Initialize nodal solver
-  nodal_solver_ = std::move(NM(NG_));
+  // User lower diffusion coefficient tolerance for finite difference method
+  if constexpr (NM::update_currents == false) {
+    Dnl_tol_ = 1.E-1;
+  }
 
-  // Initialize size of nodes_ and reconstructed_flux_params_
+  // Initialize the update frequency
+  nonlinear_update_frequency_ =
+      static_cast<std::size_t>(std::ceil(static_cast<double>(NM_) / 2.5));
+
+  // Initialize nodal solver with correct number of groups if needed
+  if (NG_ != 2) nodal_solver_ = NM(NG_);
+
+  // Initialize size of nodes_
   nodes_.resize({NM_, NG_});
-  reconstructed_flux_params_.resize({NM_, NG_});
+
+  // Only allocate memory for reconstructed flux if needed
+  if constexpr (NM::reconstruct_flux) {
+    reconstructed_flux_params_.resize({NM_, NG_});
+  }
+
+  // Set all ADFs on the nodes
   this->update_adfs();
 
   // Initialize mats_
@@ -235,13 +323,7 @@ inline NodalDiffusionDriver<NM>::NodalDiffusionDriver(
 
 template <NodalMethod NM>
 void NodalDiffusionDriver<NM>::set_flux_tolerance(double ftol) {
-  if (ftol <= 0.) {
-    auto mssg = "Tolerance for flux must be in the interval (0., 0.1).";
-    spdlog::error(mssg);
-    throw ScarabeeException(mssg);
-  }
-
-  if (ftol >= 0.1) {
+  if (ftol <= 0. || ftol >= 0.1) {
     auto mssg = "Tolerance for flux must be in the interval (0., 0.1).";
     spdlog::error(mssg);
     throw ScarabeeException(mssg);
@@ -252,13 +334,7 @@ void NodalDiffusionDriver<NM>::set_flux_tolerance(double ftol) {
 
 template <NodalMethod NM>
 void NodalDiffusionDriver<NM>::set_keff_tolerance(double ktol) {
-  if (ktol <= 0.) {
-    auto mssg = "Tolerance for keff must be in the interval (0., 0.1).";
-    spdlog::error(mssg);
-    throw ScarabeeException(mssg);
-  }
-
-  if (ktol >= 0.1) {
+  if (ktol <= 0. || ktol >= 0.1) {
     auto mssg = "Tolerance for keff must be in the interval (0., 0.1).";
     spdlog::error(mssg);
     throw ScarabeeException(mssg);
@@ -283,6 +359,35 @@ inline void NodalDiffusionDriver<NM>::set_nonlinear_update_frequency(
 }
 
 template <NodalMethod NM>
+inline void NodalDiffusionDriver<NM>::set_source_extrapolation_frequency(
+    std::size_t f) {
+  if (f == 0) {
+    auto mssg = "The source update frequency must be > 0.";
+    spdlog::error(mssg);
+    throw ScarabeeException(mssg);
+  } else if (f > 100) {
+    auto mssg = "The source update frequency is larger than 100.";
+    spdlog::warn(mssg);
+  }
+
+  source_extrapolation_frequency_ = f;
+}
+
+template <NodalMethod NM>
+inline void NodalDiffusionDriver<NM>::set_max_inner_iterations(std::size_t n) {
+  if (n == 0) {
+    auto mssg = "The max number of inner iterations must be > 0.";
+    spdlog::error(mssg);
+    throw ScarabeeException(mssg);
+  } else if (n > 20) {
+    auto mssg = "The max number of inner iterations is larger than 20.";
+    spdlog::warn(mssg);
+  }
+
+  max_bicgstab_iterations_ = n;
+}
+
+template <NodalMethod NM>
 inline void NodalDiffusionDriver<NM>::update_adfs() {
   // Get all ADFs for each node / group
   for (std::size_t m = 0; m < NM_; m++) {
@@ -300,11 +405,12 @@ inline void NodalDiffusionDriver<NM>::update_adfs() {
 
 template <NodalMethod NM>
 template <typename DiffCoeffUpdater>
-inline void NodalDiffusionDriver<NM>::update_diffusion_coefficients(
+inline double NodalDiffusionDriver<NM>::update_diffusion_coefficients(
     DiffCoeffUpdater dcu) {
   const double invs_keff = 1. / this->keff_;
 
   // Compute diffusion coefficient for each surface
+  double max_diff = 0.;
   for (const auto& surf_ind : surface_indices_) {
     const auto& surf = surf_ind.first;
     const auto i = surf_ind.second;
@@ -322,7 +428,7 @@ inline void NodalDiffusionDriver<NM>::update_diffusion_coefficients(
                                     geom_->dy(geom_inds_1[1]),
                                     geom_->dz(geom_inds_1[2])};
     const std::shared_ptr<DiffusionCrossSection>& lxs = mats_[n1].xs;
-    std::span<const Node> lnode(&nodes_(n1, 0), NG_);
+    std::span<Node> lnode(&nodes_(n1, 0), NG_);
 
     if (surf.node2) {
       // Here, we have 2 nodes. Get right node info
@@ -332,10 +438,12 @@ inline void NodalDiffusionDriver<NM>::update_diffusion_coefficients(
                                       geom_->dy(geom_inds_2[1]),
                                       geom_->dz(geom_inds_2[2])};
       const std::shared_ptr<DiffusionCrossSection>& rxs = mats_[n2].xs;
-      std::span<const Node> rnode(&nodes_(n2, 0), NG_);
+      std::span<Node> rnode(&nodes_(n2, 0), NG_);
 
       // Compute the diffusion coefficients for all groups
-      dcu(lnode, side, rnode, D, *lxs, *rxs, ldx, rdx, Dnl, invs_keff);
+      const double diff =
+          dcu(lnode, side, rnode, D, *lxs, *rxs, ldx, rdx, Dnl, invs_keff);
+      if (diff > max_diff) max_diff = diff;
     } else {
       // Here, we have a node and a boundary condition
       if (neighbors_(n1, side).first.albedo.has_value() == false) {
@@ -348,19 +456,22 @@ inline void NodalDiffusionDriver<NM>::update_diffusion_coefficients(
       const double B = neighbors_(n1, side).first.albedo.value();
 
       // Compute the diffusion coefficients for all groups
-      dcu(lnode, side, D, B, *lxs, ldx, Dnl, invs_keff);
+      const double diff = dcu(lnode, side, D, B, *lxs, ldx, Dnl, invs_keff);
+      if (diff > max_diff) max_diff = diff;
     }
   }
+  return max_diff;
 }
 
 struct PhysicalDiffCoeffUpdater {
-  void operator()(std::span<const Node> /*lnode*/, const Side side,
-                  std::span<const Node> /*rnode*/, std::span<double> D,
-                  const DiffusionCrossSection& lxs,
-                  const DiffusionCrossSection& rxs,
-                  const std::array<double, 3> ld,
-                  const std::array<double, 3> rd,
-                  std::span<const double> /*Dnl*/, const double /*invs_keff*/) {
+  double operator()(std::span<Node> /*lnode*/, const Side side,
+                    std::span<Node> /*rnode*/, std::span<double> D,
+                    const DiffusionCrossSection& lxs,
+                    const DiffusionCrossSection& rxs,
+                    const std::array<double, 3> ld,
+                    const std::array<double, 3> rd,
+                    std::span<const double> /*Dnl*/,
+                    const double /*invs_keff*/) {
     const double ldx = get_node_width(ld, side);
     const double rdx = get_node_width(rd, side);
     for (std::size_t g = 0; g < lxs.ngroups(); g++) {
@@ -368,18 +479,21 @@ struct PhysicalDiffCoeffUpdater {
       const double rD = rxs.D(g);
       D[g] = 2. * lD * rD / (ldx * lD + rdx * rD);
     }
+    return 0.;  // Fake difference
   }
 
-  void operator()(std::span<const Node> /*lnode*/, const Side side,
-                  std::span<double> D, const double B,
-                  const DiffusionCrossSection& lxs,
-                  const std::array<double, 3> ld,
-                  std::span<const double> /*Dnl*/, const double /*invs_keff*/) {
+  double operator()(std::span<Node> /*lnode*/, const Side side,
+                    std::span<double> D, const double B,
+                    const DiffusionCrossSection& lxs,
+                    const std::array<double, 3> ld,
+                    std::span<const double> /*Dnl*/,
+                    const double /*invs_keff*/) {
     const double ldx = get_node_width(ld, side);
     for (std::size_t g = 0; g < lxs.ngroups(); g++) {
       const double lD = lxs.D(g);
       D[g] = 2. * lD * (1. - B) / (4. * lD * (1. + B) + ldx * (1. - B));
     }
+    return 0.;  // Fake difference
   }
 
   double get_node_width(const std::array<double, 3>& dx, Side side) const {
@@ -401,46 +515,47 @@ struct PhysicalDiffCoeffUpdater {
 
 template <NodalMethod NM>
 struct NonlinearDiffCoeffUpdater {
-  NonlinearDiffCoeffUpdater(NM& ns) : nodal_solver(ns) {}
+  NonlinearDiffCoeffUpdater(NM& ns) : nodal_solver(&ns) {}
 
-  void operator()(std::span<const Node> lnode, const Side side,
-                  std::span<const Node> rnode, std::span<const double> D,
-                  const DiffusionCrossSection& lxs,
-                  const DiffusionCrossSection& rxs,
-                  const std::array<double, 3> ld,
-                  const std::array<double, 3> rd, std::span<double> Dnl,
-                  const double invs_keff) {
-    nodal_solver.compute_keff_nonlinear_diffusion_coefficient(
+  double operator()(std::span<Node> lnode, const Side side,
+                    std::span<Node> rnode, std::span<const double> D,
+                    const DiffusionCrossSection& lxs,
+                    const DiffusionCrossSection& rxs,
+                    const std::array<double, 3> ld,
+                    const std::array<double, 3> rd, std::span<double> Dnl,
+                    const double invs_keff) {
+    return nodal_solver->compute_keff_nonlinear_diffusion_coefficient(
         lnode, side, rnode, D, lxs, rxs, ld, rd, Dnl, invs_keff);
   }
 
-  void operator()(std::span<const Node> lnode, const Side side,
-                  std::span<const double> D, const double B,
-                  const DiffusionCrossSection& lxs,
-                  const std::array<double, 3> ld, std::span<double> Dnl,
-                  const double invs_keff) {
-    nodal_solver.compute_keff_nonlinear_diffusion_coefficient(
+  double operator()(std::span<Node> lnode, const Side side,
+                    std::span<const double> D, const double B,
+                    const DiffusionCrossSection& lxs,
+                    const std::array<double, 3> ld, std::span<double> Dnl,
+                    const double invs_keff) {
+    return nodal_solver->compute_keff_nonlinear_diffusion_coefficient(
         lnode, side, D, B, lxs, ld, Dnl, invs_keff);
   }
 
-  NM& nodal_solver;
+  NM* nodal_solver;
 };
 
 template <NodalMethod NM>
 inline void NodalDiffusionDriver<NM>::update_physical_diffusion_coefficients() {
   PhysicalDiffCoeffUpdater pdcu;
-  this->update_diffusion_coefficients<PhysicalDiffCoeffUpdater>(pdcu);
+  std::ignore =
+      this->update_diffusion_coefficients<PhysicalDiffCoeffUpdater>(pdcu);
 }
 
 template <NodalMethod NM>
-inline void
+inline double
 NodalDiffusionDriver<NM>::update_nonlinear_diffusion_coefficients() {
-  this->update_diffusion_coefficients<NonlinearDiffCoeffUpdater<NM>>(
+  return this->update_diffusion_coefficients<NonlinearDiffCoeffUpdater<NM>>(
       NonlinearDiffCoeffUpdater<NM>(this->nodal_solver_));
 }
 
 template <NodalMethod NM>
-inline void NodalDiffusionDriver<NM>::update_fluxes(Eigen::VectorXd& flux) {
+inline void NodalDiffusionDriver<NM>::update_fluxes(const Vector& flux) {
   for (std::size_t m = 0; m < NM_; m++) {
     for (std::size_t g = 0; g < NG_; g++) {
       nodes_(m, g).phi0() = flux(ind(m, g));
@@ -681,20 +796,73 @@ inline void NodalDiffusionDriver<NM>::update_transverse_leakage_coefficients() {
 }
 
 template <NodalMethod NM>
-void NodalDiffusionDriver<NM>::fill_loss_matrix(
-    Eigen::SparseMatrix<double, Eigen::RowMajor>& M) const {
-  const auto exp_len = static_cast<Eigen::Index>(NM_ * NG_);
+inline double NodalDiffusionDriver<NM>::calc_node_avg_DB2(
+    const std::size_t g, const std::size_t m, const double dx, const double dy,
+    const double dz) const {
+  const Node& node = this->nodes_(m, g);
+  double DB2 = 0.;
+  DB2 += dy * dz * (node.J_xp() - node.J_xn());
+  DB2 += dx * dz * (node.J_yp() - node.J_yn());
+  DB2 += dx * dy * (node.J_zp() - node.J_zn());
+  DB2 /= node.phi0() * dx * dy * dz;
+  return DB2;
+}
+
+template <NodalMethod NM>
+inline void NodalDiffusionDriver<NM>::update_node_xs()
+  requires(NM::update_currents)
+{
+  // Go through all nodes and groups, updating the cross sections
+  for (std::size_t m = 0; m < NM_; m++) {
+    // const auto& dd = *diff_datas_[m];
+    const DiffusionData& dd = *mats_[m].dd;
+    if (dd.leakage_corrections().has_value() == false || dd.reflector())
+      continue;
+    const auto& lc = dd.leakage_corrections().value();
+    const auto& sa_xs = *dd.xs();  // Single-Assembly (un-buckled) xs
+
+    const auto geom_indx = geom_->geom_indx(m);
+    const double del_x = geom_->dx(geom_indx[0]);
+    const double del_y = geom_->dy(geom_indx[1]);
+    const double del_z = geom_->dz(geom_indx[2]);
+    DiffusionCrossSection& xs = *mats_[m].xs;
+
+    for (std::size_t g_in = 0; g_in < NG_; g_in++) {
+      // Compute node/group leakage to loss ratio
+      const double DB2 = this->calc_node_avg_DB2(g_in, m, del_x, del_y, del_z);
+      const double LRr = DB2 / xs.Er(g_in);
+
+      // Can now determine fractional change in each group cross section
+      const double fD = lc.D(g_in) * LRr;
+      const double fEa = lc.Ea(g_in) * LRr;
+      const double fEf = lc.Ef(g_in) * LRr;
+      const double fvEf = lc.vEf(g_in) * LRr;
+
+      // Update the cross sections
+      xs.D_ref(g_in) = (fD + 1.) * sa_xs.D(g_in);
+      xs.Ea_ref(g_in) = (fEa + 1.) * sa_xs.Ea(g_in);
+      xs.Ef_ref(g_in) = (fEf + 1.) * sa_xs.Ef(g_in);
+      xs.vEf_ref(g_in) = (fvEf + 1.) * sa_xs.vEf(g_in);
+
+      for (std::size_t g_out = g_in + 1; g_out < NG_; g_out++) {
+        const double fEs = lc.Es(g_in, g_out) * LRr;
+        xs.Es_ref(g_in, g_out) = (fEs + 1.) * sa_xs.Es(g_in, g_out);
+      }
+    }
+  }
+}
+
+template <NodalMethod NM>
+void NodalDiffusionDriver<NM>::fill_loss_matrix(Matrix& M) const {
+  const Eigen::Index exp_len = static_cast<Eigen::Index>(NM_ * NG_);
   if (M.rows() != exp_len || M.cols() != exp_len) {
     // Resize the matrix if needed (usually only on first call)
     M.resize(exp_len, exp_len);
-    M.reserve(Eigen::VectorX<std::size_t>::Constant(exp_len, 6 + NG_));
+    M.reserve(Eigen::VectorX<std::size_t>::Constant(exp_len, 7 + NG_));
   } else {
     // If we are re-building the matrix, we should zero all entries first
     for (int k = 0; k < M.outerSize(); k++) {
-      for (Eigen::SparseMatrix<double, Eigen::RowMajor>::InnerIterator it(M, k);
-           it; ++it) {
-        it.valueRef() = 0.;
-      }
+      for (Matrix::InnerIterator it(M, k); it; ++it) it.valueRef() = 0.;
     }
   }
 
@@ -743,9 +911,8 @@ void NodalDiffusionDriver<NM>::fill_loss_matrix(
 }
 
 template <NodalMethod NM>
-void NodalDiffusionDriver<NM>::fill_fission_matrix(
-    Eigen::SparseMatrix<double, Eigen::RowMajor>& F) const {
-  const auto exp_len = static_cast<Eigen::Index>(NM_ * NG_);
+void NodalDiffusionDriver<NM>::fill_fission_matrix(Matrix& F) const {
+  const Eigen::Index exp_len = static_cast<Eigen::Index>(NM_ * NG_);
   if (F.rows() != exp_len || F.cols() != exp_len) {
     // Resize the matrix if needed (usually only on first call)
     F.resize(exp_len, exp_len);
@@ -753,10 +920,7 @@ void NodalDiffusionDriver<NM>::fill_fission_matrix(
   } else {
     // If we are re-building the matrix, we should zero all entries first
     for (int k = 0; k < F.outerSize(); k++) {
-      for (Eigen::SparseMatrix<double, Eigen::RowMajor>::InnerIterator it(F, k);
-           it; ++it) {
-        it.valueRef() = 0.;
-      }
+      for (Matrix::InnerIterator it(F, k); it; ++it) it.valueRef() = 0.;
     }
   }
 
@@ -772,19 +936,21 @@ void NodalDiffusionDriver<NM>::fill_fission_matrix(
         F.coeffRef(i, ind(m, gg)) += chi_g * xs.vEf(gg);
     }
   }
-
-  F.makeCompressed();
 }
 
 template <NodalMethod NM>
 void NodalDiffusionDriver<NM>::solve_keff() {
+  Timer sim_timer;
+  sim_timer.start();
+
   // Power Iteration to solve for Keff
   // Initialize flux and source vectors
-  Eigen::VectorXd new_flux(NG_ * NM_);
-  Eigen::VectorXd Q(NG_ * NM_);
+  Vector new_flux(NG_ * NM_);
+  Vector Q(NG_ * NM_);
+  Vector Q_err = Q;
 
   // Initialize a vector for computing keff faster
-  Eigen::VectorXd VvEf(NG_ * NM_);
+  Vector VvEf(NG_ * NM_);
   for (std::size_t m = 0; m < NM_; m++) {
     const DiffusionCrossSection& xs = *mats_[m].xs;
     const auto geom_inds = geom_->geom_indx(m);
@@ -801,21 +967,17 @@ void NodalDiffusionDriver<NM>::solve_keff() {
   flux_.normalize();
 
   // Initialize loss matrix and fission matrix
-  Eigen::SparseMatrix<double, Eigen::RowMajor> M;
-  Eigen::SparseMatrix<double, Eigen::RowMajor> F;
+  Matrix M;
+  Matrix F;
   fill_loss_matrix(M);
   fill_fission_matrix(F);
 
   // Create a solver for the problem
-  Eigen::BiCGSTAB<Eigen::SparseMatrix<double, Eigen::RowMajor>> solver;
-  solver.setTolerance(1.E-60);
+  Solver solver;
   solver.compute(M);
-  if (solver.info() != Eigen::Success) {
-    std::stringstream mssg;
-    mssg << "Could not initialize nodal iterative solver";
-    spdlog::error(mssg.str());
-    throw ScarabeeException(mssg.str());
-  }
+  solver.setTolerance(1.E-10);
+  solver.setMaxIterations(
+      max_bicgstab_iterations_);  // This is choice used by KOMODO
 
   // A lambda to compute the maximum flux difference
   const auto compute_max_flux_diff = [this](const auto& old_flux,
@@ -832,20 +994,33 @@ void NodalDiffusionDriver<NM>::solve_keff() {
   // Begin power iteration
   double keff_diff = 100.;
   double flux_diff = 100.;
+  double D_diff = 100.;
+  double prev_src_err = 100.;
+  double src_err = 100.;
   std::size_t iteration = 0;
-  while (keff_diff > keff_tol_ || flux_diff > flux_tol_) {
+  while (keff_diff > keff_tol_ || flux_diff > flux_tol_ || D_diff > Dnl_tol_) {
     iteration++;
     // Compute source vector
-    Q = (1. / keff_) * F * flux_;
+    Q = F * flux_;
+    Q *= 1. / keff_;
 
-    // Get new flux
+    // Compute error in the source vector
+    prev_src_err = src_err;
+    Q_err = Q - Q_err;
+    src_err = Q_err.norm();
+
+    // Source extrapolation
+    if (iteration > 3 && iteration % source_extrapolation_frequency_ == 0) {
+      spdlog::info("-------------------------------------");
+      spdlog::info("");
+      spdlog::info("Extrapolating source");
+      const double dominance_ration = src_err / prev_src_err;
+      Q += (dominance_ration / (1. - dominance_ration)) * Q_err;
+      spdlog::info("");
+    }
+
+    // Solve system
     new_flux = solver.solveWithGuess(Q, flux_);
-    // For some reason, this doesn't seem to be working with the new versions
-    // of Eigen, despite clearly succeeding. Just commenting it out for now.
-    // if (solver.info() != Eigen::Success) {
-    //   spdlog::error("Solution impossible.");
-    //   throw ScarabeeException("Solution impossible");
-    // }
 
     // Estimate keff
     double prev_keff = keff_;
@@ -865,26 +1040,741 @@ void NodalDiffusionDriver<NM>::solve_keff() {
     spdlog::info("     keff difference:     {:.5E}", keff_diff);
     spdlog::info("     max flux difference: {:.5E}", flux_diff);
 
-    if (iteration % nonlinear_update_frequency_ == 0) {
-      flux_diff = 1.;
+    if (iteration % nonlinear_update_frequency_ == 0 ||
+        (flux_diff < flux_tol_ && D_diff > Dnl_tol_)) {
+      flux_diff = 1.;  // Make sure we do at least one iteration after update
       spdlog::info("-------------------------------------");
       spdlog::info("");
       spdlog::info("Updating nonlinear diffusion coefficients");
-      spdlog::info("");
       update_fluxes(flux_);
       if (NM::update_currents) {
         update_currents();
         update_transverse_leakage_coefficients();
       }
-      update_nonlinear_diffusion_coefficients();
-      fill_loss_matrix(
-          M);  // Will also need to update this when XS is updated !
+      D_diff = update_nonlinear_diffusion_coefficients();
+      spdlog::info("Max difference: {:.5E}", D_diff);
+      spdlog::info("");
+      if constexpr (NM::update_currents) {
+        if (leakage_corrections()) {
+          update_node_xs();
+          // Only need to update F when we update the cross sections
+          fill_fission_matrix(F);
+        }
+      }
+      fill_loss_matrix(M);
       solver.compute(M);
     }
-    // TODO update_cross_sections();
+
+    Q_err = Q;
   }
 
+  // We must do one last update of the fluxes, currents, and non-linear
+  // diffusion coefficients, as this data is needed for accurate intranodal
+  // flux reconstruction.
   update_fluxes(flux_);
+  if (NM::update_currents) {
+    update_currents();
+    update_transverse_leakage_coefficients();
+  }
+  D_diff = update_nonlinear_diffusion_coefficients();
+
+  solved_ = true;
+
+  sim_timer.stop();
+  spdlog::info("");
+  spdlog::info("Simulation Time: {:.5E} s", sim_timer.elapsed_time());
+
+  if constexpr (NM::reconstruct_flux) perform_flux_reconstruction();
+}
+
+//=============================================================================
+// Flux / Power Plotting Methods
+
+template <NodalMethod NM>
+inline double NodalDiffusionDriver<NM>::flux(double x, double y, double z,
+                                             std::size_t g) const {
+  // If problem isn't solved yet, we error
+  if (solved_ == false) {
+    auto mssg = "Cannot compute flux. Problem has not been solved.";
+    spdlog::error(mssg);
+    throw ScarabeeException(mssg);
+  }
+
+  // Check group index
+  if (g >= ngroups()) {
+    std::stringstream mssg;
+    mssg << "Group index g = " << g << " is out of range.";
+    spdlog::error(mssg.str());
+    throw ScarabeeException(mssg.str());
+  }
+
+  // Get geometry index
+  const auto oi = geom_->x_to_i(x);
+  const auto oj = geom_->y_to_j(y);
+  const auto ok = geom_->z_to_k(z);
+  if (oi.has_value() == false || oj.has_value() == false ||
+      ok.has_value() == false)
+    return 0.;
+  const std::size_t i = oi.value();
+  const std::size_t j = oj.value();
+  const std::size_t k = ok.value();
+  const xt::svector<std::size_t> geom_inds{i, j, k};
+
+  // Get material index
+  const auto om = geom_->geom_to_mat_indx(geom_inds);
+  if (om.has_value() == false) return 0.;
+  const std::size_t m = om.value();
+
+  if constexpr (NM::reconstruct_flux) {
+    return reconstructed_flux_params_(m, g)(x, y, z);
+  } else {
+    return flux_(ind(m, g));
+  }
+}
+
+template <NodalMethod NM>
+inline xt::xtensor<double, 4> NodalDiffusionDriver<NM>::flux(
+    const xt::xtensor<double, 1>& x, const xt::xtensor<double, 1>& y,
+    const xt::xtensor<double, 1>& z) const {
+  // If problem isn't solved yet, we error
+  if (solved_ == false) {
+    auto mssg = "Cannot compute flux. Problem has not been solved.";
+    spdlog::error(mssg);
+    throw ScarabeeException(mssg);
+  }
+
+  // Make sure x, y, and z have at least 1 coordinate
+  if (x.size() == 0) {
+    auto mssg = "Array of x coordinates must have at least one entry.";
+    spdlog::error(mssg);
+    throw ScarabeeException(mssg);
+  }
+  if (y.size() == 0) {
+    auto mssg = "Array of y coordinates must have at least one entry.";
+    spdlog::error(mssg);
+    throw ScarabeeException(mssg);
+  }
+  if (z.size() == 0) {
+    auto mssg = "Array of z coordinates must have at least one entry.";
+    spdlog::error(mssg);
+    throw ScarabeeException(mssg);
+  }
+
+  xt::xtensor<double, 4> flux_out;
+  flux_out.resize({ngroups(), x.size(), y.size(), z.size()});
+  flux_out.fill(0.);
+
+  for (std::size_t g = 0; g < ngroups(); g++) {
+#pragma omp parallel for
+    for (int ii = 0; ii < static_cast<int>(x.size()); ii++) {
+      std::size_t i = static_cast<std::size_t>(ii);
+      for (std::size_t j = 0; j < y.size(); j++) {
+        for (std::size_t k = 0; k < z.size(); k++) {
+          // Get geometry index
+          const auto oi = geom_->x_to_i(x[i]);
+          const auto oj = geom_->y_to_j(y[j]);
+          const auto ok = geom_->z_to_k(z[k]);
+          if (oi.has_value() == false || oj.has_value() == false ||
+              ok.has_value() == false) {
+            continue;
+          }
+          const std::size_t gi = oi.value();
+          const std::size_t gj = oj.value();
+          const std::size_t gk = ok.value();
+          const xt::svector<std::size_t> geom_inds{gi, gj, gk};
+
+          // Get material index
+          const auto om = geom_->geom_to_mat_indx(geom_inds);
+          if (om.has_value() == false) continue;
+          const std::size_t m = om.value();
+
+          if constexpr (NM::reconstruct_flux) {
+            flux_out(g, i, j, k) =
+                reconstructed_flux_params_(m, g)(x[i], y[j], z[k]);
+          } else {
+            flux_out(g, i, j, k) = flux_(ind(m, g));
+          }
+        }
+      }
+    }
+  }
+
+  return flux_out;
+}
+
+template <NodalMethod NM>
+inline xt::xtensor<double, 4> NodalDiffusionDriver<NM>::avg_flux() const {
+  // If problem isn't solved yet, we error
+  if (solved_ == false) {
+    auto mssg = "Cannot compute flux. Problem has not been solved.";
+    spdlog::error(mssg);
+    throw ScarabeeException(mssg);
+  }
+
+  const std::size_t nx = geom_->nx();
+  const std::size_t ny = geom_->ny();
+  const std::size_t nz = geom_->nz();
+
+  xt::xtensor<double, 4> flux_out;
+  flux_out.resize({ngroups(), nx, ny, nz});
+
+  for (std::size_t g = 0; g < ngroups(); g++) {
+    for (std::size_t i = 0; i < nx; i++) {
+      for (std::size_t j = 0; j < ny; j++) {
+        for (std::size_t k = 0; k < nz; k++) {
+          const auto om = geom_->geom_to_mat_indx({i, j, k});
+
+          if (om.has_value() == false)
+            flux_out(g, i, j, k) = 0.;
+          else
+            flux_out(g, i, j, k) = flux_(ind(*om, g));
+        }
+      }
+    }
+  }
+
+  return flux_out;
+}
+
+template <NodalMethod NM>
+inline double NodalDiffusionDriver<NM>::power(double x, double y,
+                                              double z) const {
+  // If problem isn't solved yet, we error
+  if (solved_ == false) {
+    auto mssg = "Cannot compute power. Problem has not been solved.";
+    spdlog::error(mssg);
+    throw ScarabeeException(mssg);
+  }
+
+  // Get geometry index
+  const auto oi = geom_->x_to_i(x);
+  const auto oj = geom_->y_to_j(y);
+  const auto ok = geom_->z_to_k(z);
+  if (oi.has_value() == false || oj.has_value() == false ||
+      ok.has_value() == false)
+    return 0.;
+  const std::size_t i = oi.value();
+  const std::size_t j = oj.value();
+  const std::size_t k = ok.value();
+  const xt::svector<std::size_t> geom_inds{i, j, k};
+
+  // Get material index
+  const auto om = geom_->geom_to_mat_indx(geom_inds);
+  if (om.has_value() == false) return 0.;
+  const std::size_t m = om.value();
+
+  const auto& xs = *mats_[m].xs;
+
+  double pwr = 0.;
+
+  for (std::size_t g = 0; g < NG_; g++) {
+    if constexpr (NM::reconstruct_flux) {
+      pwr += reconstructed_flux_params_(m, g)(x, y, z) * xs.Ef(g);
+    } else {
+      pwr += flux_(ind(m, g)) * xs.Ef(g);
+    }
+  }
+
+  return pwr;
+}
+
+template <NodalMethod NM>
+inline xt::xtensor<double, 3> NodalDiffusionDriver<NM>::power(
+    const xt::xtensor<double, 1>& x, const xt::xtensor<double, 1>& y,
+    const xt::xtensor<double, 1>& z) const {
+  // If problem isn't solved yet, we error
+  if (solved_ == false) {
+    auto mssg = "Cannot compute power. Problem has not been solved.";
+    spdlog::error(mssg);
+    throw ScarabeeException(mssg);
+  }
+
+  // Make sure x, y, and z have at least 1 coordinate
+  if (x.size() == 0) {
+    auto mssg = "Array of x coordinates must have at least one entry.";
+    spdlog::error(mssg);
+    throw ScarabeeException(mssg);
+  }
+  if (y.size() == 0) {
+    auto mssg = "Array of y coordinates must have at least one entry.";
+    spdlog::error(mssg);
+    throw ScarabeeException(mssg);
+  }
+  if (z.size() == 0) {
+    auto mssg = "Array of z coordinates must have at least one entry.";
+    spdlog::error(mssg);
+    throw ScarabeeException(mssg);
+  }
+
+  xt::xtensor<double, 3> pwr_out;
+  pwr_out.resize({x.size(), y.size(), z.size()});
+  pwr_out.fill(0.);
+
+#pragma omp parallel for
+  for (int ii = 0; ii < static_cast<int>(x.size()); ii++) {
+    std::size_t i = static_cast<std::size_t>(ii);
+    for (std::size_t j = 0; j < y.size(); j++) {
+      for (std::size_t k = 0; k < z.size(); k++) {
+        // Get geometry index
+        const auto oi = geom_->x_to_i(x[i]);
+        const auto oj = geom_->y_to_j(y[j]);
+        const auto ok = geom_->z_to_k(z[k]);
+        if (oi.has_value() == false || oj.has_value() == false ||
+            ok.has_value() == false) {
+          continue;
+        }
+        const std::size_t gi = oi.value();
+        const std::size_t gj = oj.value();
+        const std::size_t gk = ok.value();
+        const xt::svector<std::size_t> geom_inds{gi, gj, gk};
+
+        // Get material index
+        const auto om = geom_->geom_to_mat_indx(geom_inds);
+        if (om.has_value() == false) {
+          continue;
+        }
+        const std::size_t m = om.value();
+
+        const auto& xs = *mats_[m].xs;
+
+        for (std::size_t g = 0; g < NG_; g++) {
+          if constexpr (NM::reconstruct_flux) {
+            pwr_out(i, j, k) +=
+                reconstructed_flux_params_(m, g)(x[i], y[j], z[k]) * xs.Ef(g);
+          } else {
+            pwr_out(i, j, k) += flux_(ind(m, g)) * xs.Ef(g);
+          }
+        }
+      }
+    }
+  }
+
+  return pwr_out;
+}
+
+template <NodalMethod NM>
+inline xt::xtensor<double, 3> NodalDiffusionDriver<NM>::avg_power() const {
+  // If problem isn't solved yet, we error
+  if (solved_ == false) {
+    auto mssg = "Cannot compute power. Problem has not been solved.";
+    spdlog::error(mssg);
+    throw ScarabeeException(mssg);
+  }
+
+  const std::size_t nx = geom_->nx();
+  const std::size_t ny = geom_->ny();
+  const std::size_t nz = geom_->nz();
+
+  xt::xtensor<double, 3> pwr_out;
+  pwr_out.resize({nx, ny, nz});
+  pwr_out.fill(0.);
+
+  for (std::size_t i = 0; i < nx; i++) {
+    for (std::size_t j = 0; j < ny; j++) {
+      for (std::size_t k = 0; k < nz; k++) {
+        const auto om = geom_->geom_to_mat_indx({i, j, k});
+
+        if (om.has_value() == false) {
+          continue;
+        }
+        const std::size_t m = om.value();
+        const auto& xs = *mats_[m].xs;
+
+        for (std::size_t g = 0; g < NG_; g++) {
+          pwr_out(i, j, k) += flux_(ind(m, g)) * xs.Ef(g);
+        }
+      }
+    }
+  }
+
+  return pwr_out;
+}
+
+//=============================================================================
+// Flux Reconstruction Methods
+
+template <NodalMethod NM>
+inline IntraNodalFlux NodalDiffusionDriver<NM>::fit_node_recon_params(
+    std::size_t g, std::size_t m) const
+  requires(NM::reconstruct_flux)
+{
+  // Get node parameters
+  const Node& node = nodes_(m, g);
+  const auto geom_indx = geom_->geom_indx(m);
+  const double dx = geom_->dx(geom_indx[0]);
+  const double dy = geom_->dy(geom_indx[1]);
+  const double dz = geom_->dz(geom_indx[2]);
+  const auto& xs = *mats_[m].xs;
+  const double D = xs.D(g);
+  const double Er = xs.Er(g);
+  const double eps = std::sqrt(Er / D);
+
+  const double x_low = geom_->x_bounds()[geom_indx[0]];
+  const double x_hi = geom_->x_bounds()[geom_indx[0] + 1];
+  const double y_low = geom_->y_bounds()[geom_indx[1]];
+  const double y_hi = geom_->y_bounds()[geom_indx[1] + 1];
+  const double z_low = geom_->z_bounds()[geom_indx[2]];
+  const double z_hi = geom_->z_bounds()[geom_indx[2] + 1];
+
+  auto sinhc = [](double x) { return std::sinh(x) / x; };
+
+  IntraNodalFlux nf;
+  nf.phi_0 = node.phi0();
+  nf.eps = eps;
+  nf.xm = 0.5 * (x_low + x_hi);
+  nf.ym = 0.5 * (y_low + y_hi);
+  nf.zm = 0.5 * (z_low + z_hi);
+  nf.invs_dx = 1. / dx;
+  nf.invs_dy = 1. / dy;
+  nf.invs_dz = 1. / dz;
+
+  // Initial base matrix for finding fx, fy, and fz coefficients
+  Eigen::Matrix<double, 4, 4> M{
+      {0., 0., 1., 1.}, {0., 0., -1., 1.}, {0., 0., 1., 3.}, {0., 0., 1., -3.}};
+  Eigen::Matrix<double, 4, 1> b;
+  Eigen::Matrix<double, 4, 1> fu_coeffs;
+
+  // Determine fx coefficients
+  const double zeta_x = 0.5 * eps * dx;
+  M(0, 0) = std::cosh(zeta_x) - sinhc(zeta_x);
+  M(0, 1) = std::sinh(zeta_x);
+  M(1, 0) = M(0, 0);
+  M(1, 1) = -M(0, 1);
+  M(2, 0) = zeta_x * std::sinh(zeta_x);
+  M(2, 1) = zeta_x * std::cosh(zeta_x);
+  M(3, 0) = -M(2, 0);
+  M(3, 1) = M(2, 1);
+  b(0) = node.phi_xp() - node.phi0();
+  b(1) = node.phi_xn() - node.phi0();
+  b(2) = -0.5 * node.J_xp() * dx / D;
+  b(3) = -0.5 * node.J_xn() * dx / D;
+  fu_coeffs = M.inverse() * b;
+  nf.ax1 = fu_coeffs(0);
+  nf.ax2 = fu_coeffs(1);
+  nf.bx1 = fu_coeffs(2);
+  nf.bx2 = fu_coeffs(3);
+  nf.ax0 = -nf.ax1 * sinhc(zeta_x);
+  nf.zeta_x = zeta_x;
+
+  // Determine fy coefficients
+  const double zeta_y = 0.5 * eps * dy;
+  M(0, 0) = std::cosh(zeta_y) - sinhc(zeta_y);
+  M(0, 1) = std::sinh(zeta_y);
+  M(1, 0) = M(0, 0);
+  M(1, 1) = -M(0, 1);
+  M(2, 0) = zeta_y * std::sinh(zeta_y);
+  M(2, 1) = zeta_y * std::cosh(zeta_y);
+  M(3, 0) = -M(2, 0);
+  M(3, 1) = M(2, 1);
+  b(0) = node.phi_yp() - node.phi0();
+  b(1) = node.phi_yn() - node.phi0();
+  b(2) = -0.5 * node.J_yp() * dy / D;
+  b(3) = -0.5 * node.J_yn() * dy / D;
+  fu_coeffs = M.inverse() * b;
+  nf.ay1 = fu_coeffs(0);
+  nf.ay2 = fu_coeffs(1);
+  nf.by1 = fu_coeffs(2);
+  nf.by2 = fu_coeffs(3);
+  nf.ay0 = -nf.ay1 * sinhc(zeta_y);
+  nf.zeta_y = zeta_y;
+
+  // Determine fz coefficients
+  const double zeta_z = 0.5 * eps * dz;
+  M(0, 0) = std::cosh(zeta_z) - sinhc(zeta_z);
+  M(0, 1) = std::sinh(zeta_z);
+  M(1, 0) = M(0, 0);
+  M(1, 1) = -M(0, 1);
+  M(2, 0) = zeta_z * std::sinh(zeta_z);
+  M(2, 1) = zeta_z * std::cosh(zeta_z);
+  M(3, 0) = -M(2, 0);
+  M(3, 1) = M(2, 1);
+  b(0) = node.phi_zp() - node.phi0();
+  b(1) = node.phi_zn() - node.phi0();
+  b(2) = -0.5 * node.J_zp() * dz / D;
+  b(3) = -0.5 * node.J_zn() * dz / D;
+  fu_coeffs = M.inverse() * b;
+  nf.az1 = fu_coeffs(0);
+  nf.az2 = fu_coeffs(1);
+  nf.bz1 = fu_coeffs(2);
+  nf.bz2 = fu_coeffs(3);
+  nf.az0 = -nf.az1 * sinhc(zeta_z);
+
+  return nf;
+}
+
+template <NodalMethod NM>
+inline void NodalDiffusionDriver<NM>::fit_node_recon_params_corners(
+    std::size_t g, std::size_t m)
+  requires(NM::reconstruct_flux)
+{
+  const auto geom_indx = geom_->geom_indx(m);
+
+  const double x_low = geom_->x_bounds()[geom_indx[0]];
+  const double x_hi = geom_->x_bounds()[geom_indx[0] + 1];
+  const double y_low = geom_->y_bounds()[geom_indx[1]];
+  const double y_hi = geom_->y_bounds()[geom_indx[1] + 1];
+
+  IntraNodalFlux& nf = reconstructed_flux_params_(m, g);
+
+  // If the corner point we are looking at is along an outer boundary,
+  // we do not compute the average value of the flux, but instead use
+  // the value estimate by the previous node reconstruction, without
+  // any cross terms. This allows the use of and f(x,y) term in the flux
+  // reconstruction on boundary nodes, without leading to the cusps that
+  // would occur when trying to take the average.
+
+  // Determine fxy coefficients
+  double flx_pp, flx_pm, flx_mp, flx_mm;
+  if (geom_indx[0] != geom_->nx() - 1 && geom_indx[1] != geom_->ny() - 1) {
+    flx_pp = avg_xy_corner_flux(g, m, Corner::PP);
+  } else {
+    flx_pp = nf.flux_xy_no_cross(x_hi, y_hi);
+  }
+
+  if (geom_indx[0] != geom_->nx() - 1 && geom_indx[1] != 0) {
+    flx_pm = avg_xy_corner_flux(g, m, Corner::PM);
+  } else {
+    flx_pm = nf.flux_xy_no_cross(x_hi, y_low);
+  }
+
+  if (geom_indx[0] != 0 && geom_indx[1] != geom_->ny() - 1) {
+    flx_mp = avg_xy_corner_flux(g, m, Corner::MP);
+  } else {
+    flx_mp = nf.flux_xy_no_cross(x_low, y_hi);
+  }
+
+  if (geom_indx[0] != 0 && geom_indx[1] != 0) {
+    flx_mm = avg_xy_corner_flux(g, m, Corner::MM);
+  } else {
+    flx_mm = nf.flux_xy_no_cross(x_low, y_low);
+  }
+
+  double pp = flx_pp - nf.flux_xy_no_cross(x_hi, y_hi);
+  double pm = flx_pm - nf.flux_xy_no_cross(x_hi, y_low);
+  double mp = flx_mp - nf.flux_xy_no_cross(x_low, y_hi);
+  double mm = flx_mm - nf.flux_xy_no_cross(x_low, y_low);
+
+  nf.cxy11 = 0.25 * (pp - pm + mm - mp);
+  nf.cxy12 = 0.25 * (pp + pm - mm - mp);
+  nf.cxy21 = 0.25 * (pp - pm - mm + mp);
+  nf.cxy22 = 0.25 * (pp + pm + mm + mp);
+}
+
+template <NodalMethod NM>
+inline double NodalDiffusionDriver<NM>::eval_heter_xy_corner_flux(
+    std::size_t g, std::size_t m, Corner c) const
+  requires(NM::reconstruct_flux)
+{
+  const IntraNodalFlux& nf = reconstructed_flux_params_(m, g);
+  const double dx = 1. / nf.invs_dx;
+  const double x_hi = nf.xm + 0.5 * dx;
+  const double x_low = nf.xm - 0.5 * dx;
+  const double dy = 1. / nf.invs_dy;
+  const double y_hi = nf.ym + 0.5 * dy;
+  const double y_low = nf.ym - 0.5 * dy;
+
+  // Since the definition of the CDF is
+  // CDF = flux_het / flux_hom
+  // we compute the heterogeneous flux as flux_het = flux_hom * CDF
+
+  switch (c) {
+    case Corner::PP:
+      return nf.flux_xy_no_cross(x_hi, y_hi) * geom_->cdf_I(m, g);
+      break;
+
+    case Corner::PM:
+      return nf.flux_xy_no_cross(x_hi, y_low) * geom_->cdf_IV(m, g);
+      break;
+
+    case Corner::MP:
+      return nf.flux_xy_no_cross(x_low, y_hi) * geom_->cdf_II(m, g);
+      break;
+
+    case Corner::MM:
+      return nf.flux_xy_no_cross(x_low, y_low) * geom_->cdf_III(m, g);
+      break;
+  }
+
+  // NEVER GETS HERE
+  return 0.;
+}
+
+template <NodalMethod NM>
+inline double NodalDiffusionDriver<NM>::avg_xy_corner_flux(std::size_t g,
+                                                           std::size_t m,
+                                                           Corner c) const
+  requires(NM::reconstruct_flux)
+{
+  const auto geom_inds = geom_->geom_indx(m);
+
+  double num = 0.;
+  double denom = 0.;
+
+  // First, we add our contribution to the corner flux estimation
+  num += eval_heter_xy_corner_flux(g, m, c);
+  denom += 1.;
+
+  if (c == Corner::PP) {
+    const auto& n_xp = neighbors_(m, Side::XP);
+    const auto& n_yp = neighbors_(m, Side::YP);
+
+    if (n_xp.second) {
+      num += eval_heter_xy_corner_flux(g, n_xp.second.value(), Corner::MP);
+      denom += 1.;
+    }
+    if (n_yp.second) {
+      num += eval_heter_xy_corner_flux(g, n_yp.second.value(), Corner::PM);
+      denom += 1.;
+    }
+
+    const auto om = geom_->geom_to_mat_indx(
+        {geom_inds[0] + 1, geom_inds[1] + 1, geom_inds[2]});
+    if (om) {
+      num += eval_heter_xy_corner_flux(g, om.value(), Corner::MM);
+      denom += 1.;
+    }
+  } else if (c == Corner::PM) {
+    const auto& n_xp = neighbors_(m, Side::XP);
+    const auto& n_ym = neighbors_(m, Side::YN);
+
+    if (n_xp.second) {
+      num += eval_heter_xy_corner_flux(g, n_xp.second.value(), Corner::MM);
+      denom += 1.;
+    }
+    if (n_ym.second) {
+      num += eval_heter_xy_corner_flux(g, n_ym.second.value(), Corner::PP);
+      denom += 1.;
+    }
+
+    const auto om = geom_->geom_to_mat_indx(
+        {geom_inds[0] + 1, geom_inds[1] - 1, geom_inds[2]});
+    if (om) {
+      num += eval_heter_xy_corner_flux(g, om.value(), Corner::MP);
+      denom += 1.;
+    }
+  } else if (c == Corner::MM) {
+    const auto& n_xm = neighbors_(m, Side::XN);
+    const auto& n_ym = neighbors_(m, Side::YN);
+
+    if (n_xm.second) {
+      num += eval_heter_xy_corner_flux(g, n_xm.second.value(), Corner::PM);
+      denom += 1.;
+    }
+    if (n_ym.second) {
+      num += eval_heter_xy_corner_flux(g, n_ym.second.value(), Corner::MP);
+      denom += 1.;
+    }
+
+    const auto om = geom_->geom_to_mat_indx(
+        {geom_inds[0] - 1, geom_inds[1] - 1, geom_inds[2]});
+    if (om) {
+      num += eval_heter_xy_corner_flux(g, om.value(), Corner::PP);
+      denom += 1.;
+    }
+  } else {  // c = Corner::MP
+    const auto& n_xm = neighbors_(m, Side::XN);
+    const auto& n_yp = neighbors_(m, Side::YP);
+
+    if (n_xm.second) {
+      num += eval_heter_xy_corner_flux(g, n_xm.second.value(), Corner::PP);
+      denom += 1.;
+    }
+    if (n_yp.second) {
+      num += eval_heter_xy_corner_flux(g, n_yp.second.value(), Corner::MM);
+      denom += 1.;
+    }
+
+    const auto om = geom_->geom_to_mat_indx(
+        {geom_inds[0] - 1, geom_inds[1] + 1, geom_inds[2]});
+    if (om) {
+      num += eval_heter_xy_corner_flux(g, om.value(), Corner::PM);
+      denom += 1.;
+    }
+  }
+
+  const double avg_het_flx = num / denom;
+
+  // The homogeneous flux is then flux_hom = flux_het / CDF
+  double CDF = 1.;
+  switch (c) {
+    case Corner::PP:
+      CDF = geom_->cdf_I(m, g);
+      break;
+
+    case Corner::PM:
+      CDF = geom_->cdf_IV(m, g);
+      break;
+
+    case Corner::MP:
+      CDF = geom_->cdf_II(m, g);
+      break;
+
+    case Corner::MM:
+      CDF = geom_->cdf_III(m, g);
+      break;
+  }
+
+  return avg_het_flx / CDF;
+}
+
+template <NodalMethod NM>
+inline void NodalDiffusionDriver<NM>::perform_flux_reconstruction()
+  requires(NM::reconstruct_flux)
+{
+  Timer fitting_timer;
+  fitting_timer.start();
+  spdlog::info("Fitting flux reconstruction parameters");
+  reconstructed_flux_params_.resize({NM_, NG_});
+#pragma omp parallel for
+  for (int im = 0; im < static_cast<int>(NM_); im++) {
+    std::size_t m = static_cast<std::size_t>(im);
+    for (std::size_t g = 0; g < NG_; g++) {
+      reconstructed_flux_params_(m, g) = fit_node_recon_params(g, m);
+    }
+  }
+#pragma omp parallel for
+  for (int im = 0; im < static_cast<int>(NM_); im++) {
+    std::size_t m = static_cast<std::size_t>(im);
+    for (std::size_t g = 0; g < NG_; g++) {
+      fit_node_recon_params_corners(g, m);
+    }
+  }
+  fitting_timer.stop();
+  spdlog::info("Fitting Time: {:.5E} s", fitting_timer.elapsed_time());
+}
+
+template <NodalMethod NM>
+inline void NodalDiffusionDriver<NM>::save(const std::string& fname) {
+  if (std::filesystem::exists(fname)) {
+    std::filesystem::remove(fname);
+  }
+
+  std::ofstream file(fname, std::ios_base::binary);
+
+  cereal::PortableBinaryOutputArchive arc(file);
+
+  arc(*this);
+}
+
+template <NodalMethod NM>
+inline std::unique_ptr<NodalDiffusionDriver<NM>> NodalDiffusionDriver<NM>::load(
+    const std::string& fname) {
+  if (std::filesystem::exists(fname) == false) {
+    std::stringstream mssg;
+    mssg << "The file \"" << fname << "\" does not exist.";
+    spdlog::error(mssg.str());
+    throw ScarabeeException(mssg.str());
+  }
+
+  std::unique_ptr<NodalDiffusionDriver> out(new NodalDiffusionDriver());
+
+  std::ifstream file(fname, std::ios_base::binary);
+
+  cereal::PortableBinaryInputArchive arc(file);
+
+  arc(*out);
+
+  return out;
 }
 
 }  // namespace scarabee

--- a/src/scarabee/_scarabee/include/diffusion/nodal_diffusion_driver.hpp
+++ b/src/scarabee/_scarabee/include/diffusion/nodal_diffusion_driver.hpp
@@ -1,0 +1,892 @@
+#ifndef SCARABEE_NODAL_DIFFUSION_DRIVER_H
+#define SCARABEE_NODAL_DIFFUSION_DRIVER_H
+
+#include <data/diffusion_cross_section.hpp>
+#include <diffusion/diffusion_data.hpp>
+#include <diffusion/diffusion_geometry.hpp>
+#include <diffusion/intra_nodal_flux.hpp>
+#include <diffusion/node.hpp>
+#include <diffusion/nodal_cmfd_surface.hpp>
+#include <diffusion/nodal_method.hpp>
+#include <utils/logging.hpp>
+#include <utils/scarabee_exception.hpp>
+
+#include <xtensor/containers/xtensor.hpp>
+
+#include <Eigen/Sparse>
+#include <Eigen/IterativeLinearSolvers>
+
+#include <Eigen/SparseLU>
+
+#include <cstddef>
+#include <memory>
+#include <optional>
+#include <span>
+#include <tuple>
+#include <unordered_map>
+
+namespace scarabee {
+
+template <NodalMethod NM>
+class NodalDiffusionDriver {
+ public:
+  NodalDiffusionDriver(std::shared_ptr<DiffusionGeometry> geom);
+
+  std::shared_ptr<DiffusionGeometry> geometry() const { return geom_; }
+
+  std::size_t ngroups() const { return NG_; }
+
+  void solve() { this->solve_keff(); }
+  bool solved() const { return solved_; }
+
+  double keff_tolerance() const { return keff_tol_; }
+  void set_keff_tolerance(double ktol);
+
+  double flux_tolerance() const { return flux_tol_; }
+  void set_flux_tolerance(double ftol);
+
+  bool leakage_corrections() const { return leakage_corrections_; }
+  void set_leakage_corrections(bool lc) { leakage_corrections_ = lc; }
+
+  std::size_t nonlinear_update_frequency() const {
+    return nonlinear_update_frequency_;
+  }
+  void set_nonlinear_update_frequency(std::size_t f);
+
+  double keff() const { return keff_; }
+
+  /*
+  double flux(double x, double y, double z, std::size_t g) const;
+  xt::xtensor<double, 4> flux(const xt::xtensor<double, 1>& x,
+                              const xt::xtensor<double, 1>& y,
+                              const xt::xtensor<double, 1>& z) const;
+  xt::xtensor<double, 4> avg_flux() const;
+
+  double power(double x, double y, double z) const;
+  xt::xtensor<double, 3> power(const xt::xtensor<double, 1>& x,
+                               const xt::xtensor<double, 1>& y,
+                               const xt::xtensor<double, 1>& z) const;
+  xt::xtensor<double, 3> avg_power() const;
+
+  void save(const std::string& fname);
+  static std::unique_ptr<NodalDiffusionDriver> load(const std::string& fname);
+  */
+
+ private:
+  struct DiffusionDataCrossSectionPair {
+    DiffusionDataCrossSectionPair(
+        const std::shared_ptr<DiffusionData>& idd,
+        const std::shared_ptr<DiffusionCrossSection>& ixs)
+        : dd(idd), xs(ixs) {}
+
+    std::shared_ptr<DiffusionData> dd;
+    std::shared_ptr<DiffusionCrossSection>
+        xs;  // Might be different from xs in dd !!
+  };
+  using NeighborInfo =
+      std::pair<DiffusionGeometry::Tile, std::optional<std::size_t>>;
+
+ private:
+  // Method relating to solve
+  void update_adfs();
+  void update_physical_diffusion_coefficients();
+  void update_nonlinear_diffusion_coefficients();
+  template <typename DiffCoeffUpdater>
+  void update_diffusion_coefficients(DiffCoeffUpdater dcu);
+  void update_fluxes(Eigen::VectorXd& flux);
+  void update_currents();
+  void update_transverse_leakage_coefficients();
+
+  void solve_keff();
+  void fill_loss_matrix(Eigen::SparseMatrix<double, Eigen::RowMajor>& M) const;
+  void fill_fission_matrix(
+      Eigen::SparseMatrix<double, Eigen::RowMajor>& F) const;
+
+  // To get index in nodal solver
+  int ind(std::size_t n, std::size_t g) const {
+    return static_cast<int>(n * NG_ + g);
+  }
+
+  std::tuple<double, double, int> get_D_Dnl_j(std::size_t n, Side s,
+                                              std::size_t g) const {
+    NodalCMFDSurface surf(n, s);
+    int j = -1;
+    const auto neighbor = this->neighbors_(n, s);
+    if (neighbor.second) {
+      std::size_t m = neighbor.second.value();
+      surf = NodalCMFDSurface(n, s, m);
+      j = ind(m, g);
+    }
+
+    const auto surf_ind = this->surface_indices_.at(surf);
+
+    return {this->surface_diffusion_coefficients_(surf_ind, 0, g),
+            this->surface_diffusion_coefficients_(surf_ind, 1, g), j};
+  };
+
+  // Reconstruction related methods
+
+ private:
+  xt::xtensor<Node, 2> nodes_;  // Node THEN Group ! Must be to make span
+  xt::xtensor<IntraNodalFlux, 2> reconstructed_flux_params_;  // Node, group
+  NM nodal_solver_;
+
+  // Neighbors for each node. Use Side present from nodal_cmfd_surface.hpp
+  // Side: XP = 0, XN = 1, YP = 2, YN = 3, ZP = 4, ZN = 5
+  xt::xtensor<NeighborInfo, 2> neighbors_;           // node, side
+  std::vector<DiffusionDataCrossSectionPair> mats_;  // Modified in solve !
+
+  // Map to convert from surface to index
+  std::unordered_map<NodalCMFDSurface, std::size_t> surface_indices_;
+
+  // Surface index, physical/nonlinear diffusion coefficient, group
+  // Must index this way so we can send continuous spans to NodalMethod
+  xt::xtensor<double, 3> surface_diffusion_coefficients_;
+
+  // Holds average flux between iterations
+  Eigen::VectorXd flux_;
+
+  std::shared_ptr<DiffusionGeometry> geom_;
+  std::size_t NG_;  // Number of groups
+  std::size_t NM_;  // Number of regions
+  std::size_t nonlinear_update_frequency_{20};
+  double keff_{1.};
+  double flux_tol_{1.E-5};
+  double keff_tol_{1.E-5};
+  bool leakage_corrections_{false};
+  bool solved_{false};
+};
+
+template <NodalMethod NM>
+inline NodalDiffusionDriver<NM>::NodalDiffusionDriver(
+    std::shared_ptr<DiffusionGeometry> geom)
+    : nodal_solver_(0), geom_(geom) {
+  if (geom_ == nullptr) {
+    const auto mssg = "Provided geometry was None.";
+    spdlog::error(mssg);
+    throw ScarabeeException(mssg);
+  }
+  if (geom_->ndims() != 3) {
+    auto mssg = "NodalDiffusionDriver requires a 3D diffusion geometry.";
+    spdlog::error(mssg);
+    throw ScarabeeException(mssg);
+  }
+
+  NG_ = geom_->ngroups();
+  NM_ = geom_->nmats();
+
+  // Initialize nodal solver
+  nodal_solver_ = std::move(NM(NG_));
+
+  // Initialize size of nodes_ and reconstructed_flux_params_
+  nodes_.resize({NM_, NG_});
+  reconstructed_flux_params_.resize({NM_, NG_});
+  this->update_adfs();
+
+  // Initialize mats_
+  mats_.reserve(NM_);
+  for (std::size_t m = 0; m < NM_; m++) {
+    const auto geom_indx = geom_->geom_indx(m);
+    const auto& diff_data = geom_->mat(geom_indx);
+    const auto& xs_ptr = diff_data->xs();
+    // Save hard copy of cross section that can be modified !
+    mats_.emplace_back(diff_data,
+                       std::make_shared<DiffusionCrossSection>(*xs_ptr));
+  }
+
+  // Initialize neighbors
+  neighbors_.resize({NM_, 6});
+  for (std::size_t m = 0; m < NM_; m++) {
+    neighbors_(m, Side::XP) = geom_->neighbor(m, Side::XP);
+    neighbors_(m, Side::XN) = geom_->neighbor(m, Side::XN);
+    neighbors_(m, Side::YP) = geom_->neighbor(m, Side::YP);
+    neighbors_(m, Side::YN) = geom_->neighbor(m, Side::YN);
+    neighbors_(m, Side::ZP) = geom_->neighbor(m, Side::ZP);
+    neighbors_(m, Side::ZN) = geom_->neighbor(m, Side::ZN);
+  }
+
+  // Initialize surface indices. First, go through and add all unique surfaces
+  // to the map
+  for (std::size_t m = 0; m < NM_; m++) {
+    for (uint8_t s = 0; s < 6; s++) {
+      Side side = static_cast<Side>(s);
+      NodalCMFDSurface surf(m, side);
+      if (neighbors_(m, s).second) {
+        surf = NodalCMFDSurface(m, side, neighbors_(m, s).second.value());
+      }
+      surface_indices_[surf] = 0;
+    }
+  }
+  // Now we go through all surfaces and index them sequentially
+  std::size_t ind = 0;
+  for (auto& surf : surface_indices_) {
+    surf.second = ind++;
+  }
+
+  // Initialize diffusion coefficients array
+  surface_diffusion_coefficients_.resize({surface_indices_.size(), 2, NG_});
+  surface_diffusion_coefficients_.fill(0.);
+  this->update_physical_diffusion_coefficients();
+
+  // Set size of flux array
+  flux_.resize(NG_ * NM_);
+  flux_.fill(1.);
+}
+
+template <NodalMethod NM>
+void NodalDiffusionDriver<NM>::set_flux_tolerance(double ftol) {
+  if (ftol <= 0.) {
+    auto mssg = "Tolerance for flux must be in the interval (0., 0.1).";
+    spdlog::error(mssg);
+    throw ScarabeeException(mssg);
+  }
+
+  if (ftol >= 0.1) {
+    auto mssg = "Tolerance for flux must be in the interval (0., 0.1).";
+    spdlog::error(mssg);
+    throw ScarabeeException(mssg);
+  }
+
+  flux_tol_ = ftol;
+}
+
+template <NodalMethod NM>
+void NodalDiffusionDriver<NM>::set_keff_tolerance(double ktol) {
+  if (ktol <= 0.) {
+    auto mssg = "Tolerance for keff must be in the interval (0., 0.1).";
+    spdlog::error(mssg);
+    throw ScarabeeException(mssg);
+  }
+
+  if (ktol >= 0.1) {
+    auto mssg = "Tolerance for keff must be in the interval (0., 0.1).";
+    spdlog::error(mssg);
+    throw ScarabeeException(mssg);
+  }
+
+  keff_tol_ = ktol;
+}
+
+template <NodalMethod NM>
+inline void NodalDiffusionDriver<NM>::set_nonlinear_update_frequency(
+    std::size_t f) {
+  if (f == 0) {
+    auto mssg = "The nonlinear update frequency must be > 0.";
+    spdlog::error(mssg);
+    throw ScarabeeException(mssg);
+  } else if (f > 100) {
+    auto mssg = "The nonlinear update frequency is larger than 100.";
+    spdlog::warn(mssg);
+  }
+
+  nonlinear_update_frequency_ = f;
+}
+
+template <NodalMethod NM>
+inline void NodalDiffusionDriver<NM>::update_adfs() {
+  // Get all ADFs for each node / group
+  for (std::size_t m = 0; m < NM_; m++) {
+    for (std::size_t g = 0; g < NG_; g++) {
+      Node& node = nodes_(m, g);
+      node.adf_xn() = geom_->adf_xn(m, g);
+      node.adf_xp() = geom_->adf_xp(m, g);
+      node.adf_yn() = geom_->adf_yn(m, g);
+      node.adf_yp() = geom_->adf_yp(m, g);
+      node.adf_zn() = geom_->adf_zn(m, g);
+      node.adf_zp() = geom_->adf_zp(m, g);
+    }
+  }
+}
+
+template <NodalMethod NM>
+template <typename DiffCoeffUpdater>
+inline void NodalDiffusionDriver<NM>::update_diffusion_coefficients(
+    DiffCoeffUpdater dcu) {
+  const double invs_keff = 1. / this->keff_;
+
+  // Compute diffusion coefficient for each surface
+  for (const auto& surf_ind : surface_indices_) {
+    const auto& surf = surf_ind.first;
+    const auto i = surf_ind.second;
+
+    // Create spans to the physical and non-linear diffusion coefficients for
+    // this surface for all energy groups.
+    std::span<double> D(&surface_diffusion_coefficients_(i, 0, 0), NG_);
+    std::span<double> Dnl(&surface_diffusion_coefficients_(i, 1, 0), NG_);
+
+    // Info for the left node
+    const std::size_t n1 = surf.node1;
+    const Side side = surf.side;
+    const auto geom_inds_1 = geom_->geom_indx(n1);
+    const std::array<double, 3> ldx{geom_->dx(geom_inds_1[0]),
+                                    geom_->dy(geom_inds_1[1]),
+                                    geom_->dz(geom_inds_1[2])};
+    const std::shared_ptr<DiffusionCrossSection>& lxs = mats_[n1].xs;
+    std::span<const Node> lnode(&nodes_(n1, 0), NG_);
+
+    if (surf.node2) {
+      // Here, we have 2 nodes. Get right node info
+      const std::size_t n2 = surf.node2.value();
+      const auto geom_inds_2 = geom_->geom_indx(n2);
+      const std::array<double, 3> rdx{geom_->dx(geom_inds_2[0]),
+                                      geom_->dy(geom_inds_2[1]),
+                                      geom_->dz(geom_inds_2[2])};
+      const std::shared_ptr<DiffusionCrossSection>& rxs = mats_[n2].xs;
+      std::span<const Node> rnode(&nodes_(n2, 0), NG_);
+
+      // Compute the diffusion coefficients for all groups
+      dcu(lnode, side, rnode, D, *lxs, *rxs, ldx, rdx, Dnl, invs_keff);
+    } else {
+      // Here, we have a node and a boundary condition
+      if (neighbors_(n1, side).first.albedo.has_value() == false) {
+        const auto mssg =
+            "Encountered node surface with no neighbor and no albedo.";
+        spdlog::error(mssg);
+        throw ScarabeeException(mssg);
+      }
+      // Albedo for the surface
+      const double B = neighbors_(n1, side).first.albedo.value();
+
+      // Compute the diffusion coefficients for all groups
+      dcu(lnode, side, D, B, *lxs, ldx, Dnl, invs_keff);
+    }
+  }
+}
+
+struct PhysicalDiffCoeffUpdater {
+  void operator()(std::span<const Node> /*lnode*/, const Side side,
+                  std::span<const Node> /*rnode*/, std::span<double> D,
+                  const DiffusionCrossSection& lxs,
+                  const DiffusionCrossSection& rxs,
+                  const std::array<double, 3> ld,
+                  const std::array<double, 3> rd,
+                  std::span<const double> /*Dnl*/, const double /*invs_keff*/) {
+    const double ldx = get_node_width(ld, side);
+    const double rdx = get_node_width(rd, side);
+    for (std::size_t g = 0; g < lxs.ngroups(); g++) {
+      const double lD = lxs.D(g);
+      const double rD = rxs.D(g);
+      D[g] = 2. * lD * rD / (ldx * lD + rdx * rD);
+    }
+  }
+
+  void operator()(std::span<const Node> /*lnode*/, const Side side,
+                  std::span<double> D, const double B,
+                  const DiffusionCrossSection& lxs,
+                  const std::array<double, 3> ld,
+                  std::span<const double> /*Dnl*/, const double /*invs_keff*/) {
+    const double ldx = get_node_width(ld, side);
+    for (std::size_t g = 0; g < lxs.ngroups(); g++) {
+      const double lD = lxs.D(g);
+      D[g] = 2. * lD * (1. - B) / (4. * lD * (1. + B) + ldx * (1. - B));
+    }
+  }
+
+  double get_node_width(const std::array<double, 3>& dx, Side side) const {
+    switch (side) {
+      case Side::XP:
+      case Side::XN:
+        return dx[0];
+      case Side::YP:
+      case Side::YN:
+        return dx[1];
+      case Side::ZP:
+      case Side::ZN:
+        return dx[2];
+      default:
+        return dx[0];  // Should never get here !
+    }
+  }
+};
+
+template <NodalMethod NM>
+struct NonlinearDiffCoeffUpdater {
+  NonlinearDiffCoeffUpdater(NM& ns) : nodal_solver(ns) {}
+
+  void operator()(std::span<const Node> lnode, const Side side,
+                  std::span<const Node> rnode, std::span<const double> D,
+                  const DiffusionCrossSection& lxs,
+                  const DiffusionCrossSection& rxs,
+                  const std::array<double, 3> ld,
+                  const std::array<double, 3> rd, std::span<double> Dnl,
+                  const double invs_keff) {
+    nodal_solver.compute_keff_nonlinear_diffusion_coefficient(
+        lnode, side, rnode, D, lxs, rxs, ld, rd, Dnl, invs_keff);
+  }
+
+  void operator()(std::span<const Node> lnode, const Side side,
+                  std::span<const double> D, const double B,
+                  const DiffusionCrossSection& lxs,
+                  const std::array<double, 3> ld, std::span<double> Dnl,
+                  const double invs_keff) {
+    nodal_solver.compute_keff_nonlinear_diffusion_coefficient(
+        lnode, side, D, B, lxs, ld, Dnl, invs_keff);
+  }
+
+  NM& nodal_solver;
+};
+
+template <NodalMethod NM>
+inline void NodalDiffusionDriver<NM>::update_physical_diffusion_coefficients() {
+  PhysicalDiffCoeffUpdater pdcu;
+  this->update_diffusion_coefficients<PhysicalDiffCoeffUpdater>(pdcu);
+}
+
+template <NodalMethod NM>
+inline void
+NodalDiffusionDriver<NM>::update_nonlinear_diffusion_coefficients() {
+  this->update_diffusion_coefficients<NonlinearDiffCoeffUpdater<NM>>(
+      NonlinearDiffCoeffUpdater<NM>(this->nodal_solver_));
+}
+
+template <NodalMethod NM>
+inline void NodalDiffusionDriver<NM>::update_fluxes(Eigen::VectorXd& flux) {
+  for (std::size_t m = 0; m < NM_; m++) {
+    for (std::size_t g = 0; g < NG_; g++) {
+      nodes_(m, g).phi0() = flux(ind(m, g));
+    }
+  }
+}
+
+template <NodalMethod NM>
+inline void NodalDiffusionDriver<NM>::update_currents() {
+  // Go through each surface
+  for (const auto& surf_ind : surface_indices_) {
+    const auto surf = surf_ind.first;
+    const auto ind = surf_ind.second;
+
+    for (std::size_t g = 0; g < NG_; g++) {
+      const double D = surface_diffusion_coefficients_(ind, 0, g);
+      const double Dnl = surface_diffusion_coefficients_(ind, 1, g);
+      const double phi_n1 = nodes_(surf.node1, g).phi0();
+
+      const double J = [g, D, Dnl, phi_n1, &surf, this]() -> double {
+        if (surf.node2) {
+          const double phi_n2 = nodes_(surf.node2.value(), g).phi0();
+          return -D * (phi_n2 - phi_n1) - Dnl * (phi_n2 + phi_n1);
+        } else if (surf.side == Side::XP || surf.side == Side::YP ||
+                   surf.side == Side::ZP) {
+          return (D - Dnl) * phi_n1;
+        } else {
+          return -(D + Dnl) * phi_n1;
+        }
+      }();
+
+      switch (surf.side) {
+        case Side::XN:
+          nodes_(surf.node1, g).J_xn() = J;
+          if (surf.node2) nodes_(surf.node2.value(), g).J_xp() = J;
+          break;
+        case Side::XP:
+          nodes_(surf.node1, g).J_xp() = J;
+          if (surf.node2) nodes_(surf.node2.value(), g).J_xn() = J;
+          break;
+        case Side::YN:
+          nodes_(surf.node1, g).J_yn() = J;
+          if (surf.node2) nodes_(surf.node2.value(), g).J_yp() = J;
+          break;
+        case Side::YP:
+          nodes_(surf.node1, g).J_yp() = J;
+          if (surf.node2) nodes_(surf.node2.value(), g).J_yn() = J;
+          break;
+        case Side::ZN:
+          nodes_(surf.node1, g).J_zn() = J;
+          if (surf.node2) nodes_(surf.node2.value(), g).J_zp() = J;
+          break;
+        case Side::ZP:
+          nodes_(surf.node1, g).J_zp() = J;
+          if (surf.node2) nodes_(surf.node2.value(), g).J_zn() = J;
+          break;
+      }
+    }
+  }
+}
+
+template <NodalMethod NM>
+inline void NodalDiffusionDriver<NM>::update_transverse_leakage_coefficients() {
+  for (std::size_t m = 0; m < NM_; m++) {
+    for (std::size_t g = 0; g < NG_; g++) {
+      Node& node = nodes_(m, g);
+
+      // Get the currents along each axis at the positive and negative bounds
+      const double Jxp = node.J_xp();
+      const double Jxm = node.J_xn();
+      const double Jyp = node.J_yp();
+      const double Jym = node.J_yn();
+      const double Jzp = node.J_zp();
+      const double Jzm = node.J_zn();
+
+      // Compute average transverse leakages in each direction
+      const double Lx = Jxp - Jxm;
+      const double Ly = Jyp - Jym;
+      const double Lz = Jzp - Jzm;
+
+      // Get neighbor info
+      const auto& n_xp = neighbors_(m, Side::XP);
+      const auto& n_xm = neighbors_(m, Side::XN);
+      const auto& n_yp = neighbors_(m, Side::YP);
+      const auto& n_ym = neighbors_(m, Side::YN);
+      const auto& n_zp = neighbors_(m, Side::ZP);
+      const auto& n_zm = neighbors_(m, Side::ZN);
+
+      // Obtain geometry spacings for node
+      const auto geom_indxs = geom_->geom_indx(m);
+      const double dx = geom_->dx(geom_indxs[0]);
+      const double dy = geom_->dy(geom_indxs[1]);
+      const double dz = geom_->dz(geom_indxs[2]);
+      const double invs_dx = 1. / dx;
+      const double invs_dy = 1. / dy;
+      const double invs_dz = 1. / dz;
+
+      // This returns the average transverse leakage moments for a given node
+      auto comp_avg_trans_lks = [this](std::size_t g, std::size_t m) {
+        const Node& n = this->nodes_(m, g);
+
+        const double Jxp = n.J_xp();
+        const double Jxm = n.J_xn();
+        const double Jyp = n.J_yp();
+        const double Jym = n.J_yn();
+        const double Jzp = n.J_zp();
+        const double Jzm = n.J_zn();
+
+        const double Lx = Jxp - Jxm;
+        const double Ly = Jyp - Jym;
+        const double Lz = Jzp - Jzm;
+
+        return std::array<double, 3>{Lx, Ly, Lz};
+      };
+
+      std::array<double, 3> tmp;
+      // x-axis
+      if (n_xp.second && n_xm.second) {
+        const double dx_xp = geom_->dx(geom_indxs[0] + 1);
+        const double dx_xm = geom_->dx(geom_indxs[0] - 1);
+        const double eta_xp = dx_xp * invs_dx;
+        const double eta_xm = dx_xm * invs_dx;
+        const double p1xm = eta_xm + 1.;
+        const double p2xm = 2. * eta_xm + 1.;
+        const double p1xp = eta_xp + 1.;
+        const double p2xp = 2. * eta_xp + 1.;
+        const double invs_denom = 1. / (p1xp * p1xm * (eta_xp + eta_xm + 1.));
+
+        tmp = comp_avg_trans_lks(g, n_xp.second.value());
+        const double Ly_xp = tmp[1];
+        const double Lz_xp = tmp[2];
+
+        tmp = comp_avg_trans_lks(g, n_xm.second.value());
+        const double Ly_xm = tmp[1];
+        const double Lz_xm = tmp[2];
+
+        node.Lx_rho_y1() = (p1xm * p2xm * Ly_xp - p1xp * p2xp * Ly_xm +
+                            (p1xp * p2xp - p1xm * p2xm) * Ly) *
+                           invs_denom;
+        node.Lx_rho_y2() =
+            (p1xm * Ly_xp + p1xp * Ly_xm - (eta_xp + eta_xm + 2.) * Ly) *
+            invs_denom;
+
+        node.Lx_rho_z1() = (p1xm * p2xm * Lz_xp - p1xp * p2xp * Lz_xm +
+                            (p1xp * p2xp - p1xm * p2xm) * Lz) *
+                           invs_denom;
+        node.Lx_rho_z2() =
+            (p1xm * Lz_xp + p1xp * Lz_xm - (eta_xp + eta_xm + 2.) * Lz) *
+            invs_denom;
+      } else {
+        node.Lx_rho_y1() = 0.;
+        node.Lx_rho_y2() = 0.;
+        node.Lx_rho_z1() = 0.;
+        node.Lx_rho_z2() = 0.;
+      }
+
+      // y-axis
+      if (n_yp.second && n_ym.second) {
+        const double dy_yp = geom_->dy(geom_indxs[1] + 1);
+        const double dy_ym = geom_->dy(geom_indxs[1] - 1);
+        const double eta_yp = dy_yp * invs_dy;
+        const double eta_ym = dy_ym * invs_dy;
+        const double p1ym = eta_ym + 1.;
+        const double p2ym = 2. * eta_ym + 1.;
+        const double p1yp = eta_yp + 1.;
+        const double p2yp = 2. * eta_yp + 1.;
+        const double invs_denom = 1. / (p1yp * p1ym * (eta_yp + eta_ym + 1.));
+
+        tmp = comp_avg_trans_lks(g, n_yp.second.value());
+        const double Lx_yp = tmp[0];
+        const double Lz_yp = tmp[2];
+
+        tmp = comp_avg_trans_lks(g, n_ym.second.value());
+        const double Lx_ym = tmp[0];
+        const double Lz_ym = tmp[2];
+
+        node.Ly_rho_x1() = (p1ym * p2ym * Lx_yp - p1yp * p2yp * Lx_ym +
+                            (p1yp * p2yp - p1ym * p2ym) * Lx) *
+                           invs_denom;
+        node.Ly_rho_x2() =
+            (p1ym * Lx_yp + p1yp * Lx_ym - (eta_yp + eta_ym + 2.) * Lx) *
+            invs_denom;
+
+        node.Ly_rho_z1() = (p1ym * p2ym * Lz_yp - p1yp * p2yp * Lz_ym +
+                            (p1yp * p2yp - p1ym * p2ym) * Lz) *
+                           invs_denom;
+        node.Ly_rho_z2() =
+            (p1ym * Lz_yp + p1yp * Lz_ym - (eta_yp + eta_ym + 2.) * Lz) *
+            invs_denom;
+      } else {
+        node.Ly_rho_x1() = 0.;
+        node.Ly_rho_x2() = 0.;
+        node.Ly_rho_z1() = 0.;
+        node.Ly_rho_z2() = 0.;
+      }
+
+      // z-axis
+      if (n_zp.second && n_zm.second) {
+        const double dz_zp = geom_->dz(geom_indxs[2] + 1);
+        const double dz_zm = geom_->dz(geom_indxs[2] - 1);
+        const double eta_zp = dz_zp * invs_dz;
+        const double eta_zm = dz_zm * invs_dz;
+        const double p1zm = eta_zm + 1.;
+        const double p2zm = 2. * eta_zm + 1.;
+        const double p1zp = eta_zp + 1.;
+        const double p2zp = 2. * eta_zp + 1.;
+        const double invs_denom = 1. / (p1zp * p1zm * (eta_zp + eta_zm + 1.));
+
+        tmp = comp_avg_trans_lks(g, n_zp.second.value());
+        const double Lx_zp = tmp[0];
+        const double Ly_zp = tmp[1];
+
+        tmp = comp_avg_trans_lks(g, n_zm.second.value());
+        const double Lx_zm = tmp[0];
+        const double Ly_zm = tmp[1];
+
+        node.Lz_rho_x1() = (p1zm * p2zm * Lx_zp - p1zp * p2zp * Lx_zm +
+                            (p1zp * p2zp - p1zm * p2zm) * Lx) *
+                           invs_denom;
+        node.Lz_rho_x2() =
+            (p1zm * Lx_zp + p1zp * Lx_zm - (eta_zp + eta_zm + 2.) * Lx) *
+            invs_denom;
+
+        node.Lz_rho_y1() = (p1zm * p2zm * Ly_zp - p1zp * p2zp * Ly_zm +
+                            (p1zp * p2zp - p1zm * p2zm) * Ly) *
+                           invs_denom;
+        node.Lz_rho_y2() =
+            (p1zm * Ly_zp + p1zp * Ly_zm - (eta_zp + eta_zm + 2.) * Ly) *
+            invs_denom;
+      } else {
+        node.Lz_rho_x1() = 0.;
+        node.Lz_rho_x2() = 0.;
+        node.Lz_rho_y1() = 0.;
+        node.Lz_rho_y2() = 0.;
+      }
+    }
+  }
+}
+
+template <NodalMethod NM>
+void NodalDiffusionDriver<NM>::fill_loss_matrix(
+    Eigen::SparseMatrix<double, Eigen::RowMajor>& M) const {
+  const auto exp_len = static_cast<Eigen::Index>(NM_ * NG_);
+  if (M.rows() != exp_len || M.cols() != exp_len) {
+    // Resize the matrix if needed (usually only on first call)
+    M.resize(exp_len, exp_len);
+    M.reserve(Eigen::VectorX<std::size_t>::Constant(exp_len, 6 + NG_));
+  } else {
+    // If we are re-building the matrix, we should zero all entries first
+    for (int k = 0; k < M.outerSize(); k++) {
+      for (Eigen::SparseMatrix<double, Eigen::RowMajor>::InnerIterator it(M, k);
+           it; ++it) {
+        it.valueRef() = 0.;
+      }
+    }
+  }
+
+  // Next, we re-build the matrix from scratch.
+  for (std::size_t m = 0; m < NM_; m++) {
+    const DiffusionCrossSection& xs = *mats_[m].xs;
+    const auto geom_inds = this->geom_->geom_indx(m);
+    const double invs_dx = 1. / geom_->dx(geom_inds[0]);
+    const double invs_dy = 1. / geom_->dy(geom_inds[1]);
+    const double invs_dz = 1. / geom_->dz(geom_inds[2]);
+
+    for (std::size_t g = 0; g < NG_; g++) {
+      const auto i = ind(m, g);
+
+      // Handle leakage along x
+      const auto [D_xn, Dnl_xn, j_xn] = get_D_Dnl_j(m, Side::XN, g);
+      const auto [D_xp, Dnl_xp, j_xp] = get_D_Dnl_j(m, Side::XP, g);
+      if (j_xn >= 0) M.coeffRef(i, j_xn) += (Dnl_xn - D_xn) * invs_dx;
+      M.coeffRef(i, i) += (D_xn + D_xp + Dnl_xn - Dnl_xp) * invs_dx;
+      if (j_xp >= 0) M.coeffRef(i, j_xp) += (-D_xp - Dnl_xp) * invs_dx;
+
+      // Handle leakage along y
+      const auto [D_yn, Dnl_yn, j_yn] = get_D_Dnl_j(m, Side::YN, g);
+      const auto [D_yp, Dnl_yp, j_yp] = get_D_Dnl_j(m, Side::YP, g);
+      if (j_yn >= 0) M.coeffRef(i, j_yn) += (Dnl_yn - D_yn) * invs_dy;
+      M.coeffRef(i, i) += (D_yn + D_yp + Dnl_yn - Dnl_yp) * invs_dy;
+      if (j_yp >= 0) M.coeffRef(i, j_yp) += (-D_yp - Dnl_yp) * invs_dy;
+
+      // Handle leakage along z
+      const auto [D_zn, Dnl_zn, j_zn] = get_D_Dnl_j(m, Side::ZN, g);
+      const auto [D_zp, Dnl_zp, j_zp] = get_D_Dnl_j(m, Side::ZP, g);
+      if (j_zn >= 0) M.coeffRef(i, j_zn) += (Dnl_zn - D_zn) * invs_dz;
+      M.coeffRef(i, i) += (D_zn + D_zp + Dnl_zn - Dnl_zp) * invs_dz;
+      if (j_zp >= 0) M.coeffRef(i, j_zp) += (-D_zp - Dnl_zp) * invs_dz;
+
+      // Handle removal
+      M.coeffRef(i, i) += xs.Er(g);
+
+      // Handle scattering
+      for (std::size_t gg = 0; gg < NG_; gg++)
+        if (gg != g) M.coeffRef(i, ind(m, gg)) -= xs.Es(gg, g);
+    }
+  }
+
+  M.makeCompressed();
+}
+
+template <NodalMethod NM>
+void NodalDiffusionDriver<NM>::fill_fission_matrix(
+    Eigen::SparseMatrix<double, Eigen::RowMajor>& F) const {
+  const auto exp_len = static_cast<Eigen::Index>(NM_ * NG_);
+  if (F.rows() != exp_len || F.cols() != exp_len) {
+    // Resize the matrix if needed (usually only on first call)
+    F.resize(exp_len, exp_len);
+    F.reserve(Eigen::VectorX<std::size_t>::Constant(exp_len, NG_));
+  } else {
+    // If we are re-building the matrix, we should zero all entries first
+    for (int k = 0; k < F.outerSize(); k++) {
+      for (Eigen::SparseMatrix<double, Eigen::RowMajor>::InnerIterator it(F, k);
+           it; ++it) {
+        it.valueRef() = 0.;
+      }
+    }
+  }
+
+  // Next, we re-build the matrix from scratch.
+  for (std::size_t m = 0; m < NM_; m++) {
+    const DiffusionCrossSection& xs = *mats_[m].xs;
+
+    for (std::size_t g = 0; g < NG_; g++) {
+      const double chi_g = xs.chi(g);
+      const auto i = ind(m, g);
+
+      for (std::size_t gg = 0; gg < NG_; gg++)
+        F.coeffRef(i, ind(m, gg)) += chi_g * xs.vEf(gg);
+    }
+  }
+
+  F.makeCompressed();
+}
+
+template <NodalMethod NM>
+void NodalDiffusionDriver<NM>::solve_keff() {
+  // Power Iteration to solve for Keff
+  // Initialize flux and source vectors
+  Eigen::VectorXd new_flux(NG_ * NM_);
+  Eigen::VectorXd Q(NG_ * NM_);
+
+  // Initialize a vector for computing keff faster
+  Eigen::VectorXd VvEf(NG_ * NM_);
+  for (std::size_t m = 0; m < NM_; m++) {
+    const DiffusionCrossSection& xs = *mats_[m].xs;
+    const auto geom_inds = geom_->geom_indx(m);
+    const double dx = geom_->dx(geom_inds[0]);
+    const double dy = geom_->dy(geom_inds[1]);
+    const double dz = geom_->dz(geom_inds[2]);
+    const double V = dx * dy * dz;
+    for (std::size_t g = 0; g < NG_; g++) {
+      VvEf(ind(m, g)) = V * xs.vEf(g);
+    }
+  }
+
+  // Ensure flux is normalized
+  flux_.normalize();
+
+  // Initialize loss matrix and fission matrix
+  Eigen::SparseMatrix<double, Eigen::RowMajor> M;
+  Eigen::SparseMatrix<double, Eigen::RowMajor> F;
+  fill_loss_matrix(M);
+  fill_fission_matrix(F);
+
+  // Create a solver for the problem
+  Eigen::BiCGSTAB<Eigen::SparseMatrix<double, Eigen::RowMajor>> solver;
+  solver.setTolerance(1.E-60);
+  solver.compute(M);
+  if (solver.info() != Eigen::Success) {
+    std::stringstream mssg;
+    mssg << "Could not initialize nodal iterative solver";
+    spdlog::error(mssg.str());
+    throw ScarabeeException(mssg.str());
+  }
+
+  // A lambda to compute the maximum flux difference
+  const auto compute_max_flux_diff = [this](const auto& old_flux,
+                                            const auto& new_flux) -> double {
+    double flux_diff = 0.;
+    for (std::size_t i = 0; i < NM_ * NG_; i++) {
+      const double flux_diff_i =
+          std::abs(new_flux(i) - old_flux(i)) / new_flux(i);
+      if (flux_diff_i > flux_diff) flux_diff = flux_diff_i;
+    }
+    return flux_diff;
+  };
+
+  // Begin power iteration
+  double keff_diff = 100.;
+  double flux_diff = 100.;
+  std::size_t iteration = 0;
+  while (keff_diff > keff_tol_ || flux_diff > flux_tol_) {
+    iteration++;
+    // Compute source vector
+    Q = (1. / keff_) * F * flux_;
+
+    // Get new flux
+    new_flux = solver.solveWithGuess(Q, flux_);
+    // For some reason, this doesn't seem to be working with the new versions
+    // of Eigen, despite clearly succeeding. Just commenting it out for now.
+    // if (solver.info() != Eigen::Success) {
+    //   spdlog::error("Solution impossible.");
+    //   throw ScarabeeException("Solution impossible");
+    // }
+
+    // Estimate keff
+    double prev_keff = keff_;
+    keff_ = prev_keff * (VvEf.dot(new_flux) / VvEf.dot(flux_));
+    keff_diff = std::abs(keff_ - prev_keff) / keff_;
+
+    // Normalize our new flux
+    new_flux *= prev_keff / keff_;
+
+    // Find the max flux error
+    flux_diff = compute_max_flux_diff(flux_, new_flux);
+    flux_ = new_flux;
+
+    // Write information
+    spdlog::info("-------------------------------------");
+    spdlog::info("Iteration {:>4d}          keff: {:.5f}", iteration, keff_);
+    spdlog::info("     keff difference:     {:.5E}", keff_diff);
+    spdlog::info("     max flux difference: {:.5E}", flux_diff);
+
+    if (iteration % nonlinear_update_frequency_ == 0) {
+      flux_diff = 1.;
+      spdlog::info("-------------------------------------");
+      spdlog::info("");
+      spdlog::info("Updating nonlinear diffusion coefficients");
+      spdlog::info("");
+      update_fluxes(flux_);
+      if (NM::update_currents) {
+        update_currents();
+        update_transverse_leakage_coefficients();
+      }
+      update_nonlinear_diffusion_coefficients();
+      fill_loss_matrix(
+          M);  // Will also need to update this when XS is updated !
+      solver.compute(M);
+    }
+    // TODO update_cross_sections();
+  }
+
+  update_fluxes(flux_);
+}
+
+}  // namespace scarabee
+
+#endif

--- a/src/scarabee/_scarabee/include/diffusion/nodal_method.hpp
+++ b/src/scarabee/_scarabee/include/diffusion/nodal_method.hpp
@@ -1,9 +1,7 @@
 #ifndef SCARABEE_NODAL_METHOD_H
 #define SCARABEE_NODAL_METHOD_H
 
-#include <diffusion/node.hpp>
 #include <diffusion/nodal_cmfd_surface.hpp>
-#include <data/diffusion_cross_section.hpp>
 
 #include <array>
 #include <cstddef>
@@ -12,17 +10,20 @@
 
 namespace scarabee {
 
+class Node;
+class DiffusionCrossSection;
+
 // Concept for NodalMethod
 template <typename NM>
 concept NodalMethod = requires(
-    NM nm,                        // Nodal Method
-    std::size_t NG,               // Number of groups
-    std::span<const Node> lnode,  // Node on left (-) side of surface
-    std::span<const Node> rnode,  // Node on right (+) side of surface
-    const Side side,              // Side of lnode which is the treated surface
-    std::span<const double> D,    // Physical diffusion coefficients for surface
-    std::span<double> Dnl,        // Nonlinear diffusion coefficients to update
-    const double B,               // Albedo for the boundary condition
+    NM nm,                      // Nodal Method
+    std::size_t NG,             // Number of groups
+    std::span<Node> lnode,      // Node on left (-) side of surface
+    std::span<Node> rnode,      // Node on right (+) side of surface
+    const Side side,            // Side of lnode which is the treated surface
+    std::span<const double> D,  // Physical diffusion coefficients for surface
+    std::span<double> Dnl,      // Nonlinear diffusion coefficients to update
+    const double B,             // Albedo for the boundary condition
     const std::array<double, 3> ld,    // Widths of the left node
     const std::array<double, 3> rd,    // Widths of the right node
     const double invs_keff,            // Latest estimate of keff
@@ -30,14 +31,15 @@ concept NodalMethod = requires(
     const DiffusionCrossSection& rxs) {
   { NM(NG) };
   { NM::update_currents } -> std::convertible_to<bool>;
+  { NM::reconstruct_flux } -> std::convertible_to<bool>;
   {
     nm.compute_keff_nonlinear_diffusion_coefficient(lnode, side, rnode, D, lxs,
                                                     rxs, ld, rd, Dnl, invs_keff)
-  } -> std::same_as<void>;  // Two-Node Problem
+  } -> std::same_as<double>;  // Two-Node Problem
   {
     nm.compute_keff_nonlinear_diffusion_coefficient(lnode, side, D, B, lxs, ld,
                                                     Dnl, invs_keff)
-  } -> std::same_as<void>;  // One-Node Problem
+  } -> std::same_as<double>;  // One-Node Problem
 };
 
 }  // namespace scarabee

--- a/src/scarabee/_scarabee/include/diffusion/nodal_method.hpp
+++ b/src/scarabee/_scarabee/include/diffusion/nodal_method.hpp
@@ -1,0 +1,45 @@
+#ifndef SCARABEE_NODAL_METHOD_H
+#define SCARABEE_NODAL_METHOD_H
+
+#include <diffusion/node.hpp>
+#include <diffusion/nodal_cmfd_surface.hpp>
+#include <data/diffusion_cross_section.hpp>
+
+#include <array>
+#include <cstddef>
+#include <concepts>
+#include <span>
+
+namespace scarabee {
+
+// Concept for NodalMethod
+template <typename NM>
+concept NodalMethod = requires(
+    NM nm,                        // Nodal Method
+    std::size_t NG,               // Number of groups
+    std::span<const Node> lnode,  // Node on left (-) side of surface
+    std::span<const Node> rnode,  // Node on right (+) side of surface
+    const Side side,              // Side of lnode which is the treated surface
+    std::span<const double> D,    // Physical diffusion coefficients for surface
+    std::span<double> Dnl,        // Nonlinear diffusion coefficients to update
+    const double B,               // Albedo for the boundary condition
+    const std::array<double, 3> ld,    // Widths of the left node
+    const std::array<double, 3> rd,    // Widths of the right node
+    const double invs_keff,            // Latest estimate of keff
+    const DiffusionCrossSection& lxs,  // XS of the left node
+    const DiffusionCrossSection& rxs) {
+  { NM(NG) };
+  { NM::update_currents } -> std::convertible_to<bool>;
+  {
+    nm.compute_keff_nonlinear_diffusion_coefficient(lnode, side, rnode, D, lxs,
+                                                    rxs, ld, rd, Dnl, invs_keff)
+  } -> std::same_as<void>;  // Two-Node Problem
+  {
+    nm.compute_keff_nonlinear_diffusion_coefficient(lnode, side, D, B, lxs, ld,
+                                                    Dnl, invs_keff)
+  } -> std::same_as<void>;  // One-Node Problem
+};
+
+}  // namespace scarabee
+
+#endif

--- a/src/scarabee/_scarabee/include/diffusion/node.hpp
+++ b/src/scarabee/_scarabee/include/diffusion/node.hpp
@@ -103,13 +103,33 @@ class Node {
   double adf_zn() const { return data_[24]; }
   double& adf_zn() { return data_[24]; }
 
+  // Surface fluxes
+  double phi_xp() const { return data_[25]; }
+  double& phi_xp() { return data_[25]; }
+
+  double phi_xn() const { return data_[26]; }
+  double& phi_xn() { return data_[26]; }
+
+  double phi_yp() const { return data_[27]; }
+  double& phi_yp() { return data_[27]; }
+
+  double phi_yn() const { return data_[28]; }
+  double& phi_yn() { return data_[28]; }
+
+  double phi_zp() const { return data_[29]; }
+  double& phi_zp() { return data_[29]; }
+
+  double phi_zn() const { return data_[30]; }
+  double& phi_zn() { return data_[30]; }
+
  private:
   // - The average flux phi
   // - Must know 6 Net Currents (each node face)
   // - For each direction, must know transverse leakage coeffs px1, px2, etc
   //   Must know 12 transverse leakage coefficients
   // - Must know 6 ADFs, one for each side
-  std::array<double, 25> data_;
+  // - Must know 6 surface fluxes
+  std::array<double, 31> data_;
 
   friend class cereal::access;
   template <class Archive>

--- a/src/scarabee/_scarabee/include/diffusion/node.hpp
+++ b/src/scarabee/_scarabee/include/diffusion/node.hpp
@@ -1,0 +1,122 @@
+#ifndef SCARABEE_NODE_H
+#define SCARABEE_NODE_H
+
+#include <cereal/cereal.hpp>
+#include <cereal/types/array.hpp>
+
+#include <array>
+
+namespace scarabee {
+
+class Node {
+ public:
+  Node() : data_() {
+    data_.fill(0.);
+
+    // Initialize ADFs to 1
+    this->adf_xp() = 1.;
+    this->adf_xn() = 1.;
+    this->adf_yp() = 1.;
+    this->adf_yn() = 1.;
+    this->adf_zp() = 1.;
+    this->adf_zn() = 1.;
+  }
+
+  // Average flux
+  double phi0() const { return data_[0]; }
+  double& phi0() { return data_[0]; }
+
+  // Average Surface Currents
+  double J_xp() const { return data_[1]; }
+  double& J_xp() { return data_[1]; }
+
+  double J_xn() const { return data_[2]; }
+  double& J_xn() { return data_[2]; }
+
+  double J_yp() const { return data_[3]; }
+  double& J_yp() { return data_[3]; }
+
+  double J_yn() const { return data_[4]; }
+  double& J_yn() { return data_[4]; }
+
+  double J_zp() const { return data_[5]; }
+  double& J_zp() { return data_[5]; }
+
+  double J_zn() const { return data_[6]; }
+  double& J_zn() { return data_[6]; }
+
+  // Expansion terms for the transverse leakage when solving for x
+  double Lx_rho_y1() const { return data_[7]; }
+  double& Lx_rho_y1() { return data_[7]; }
+
+  double Lx_rho_y2() const { return data_[8]; }
+  double& Lx_rho_y2() { return data_[8]; }
+
+  double Lx_rho_z1() const { return data_[9]; }
+  double& Lx_rho_z1() { return data_[9]; }
+
+  double Lx_rho_z2() const { return data_[10]; }
+  double& Lx_rho_z2() { return data_[10]; }
+
+  // Expansion terms for the transverse leakage when solving for y
+  double Ly_rho_x1() const { return data_[11]; }
+  double& Ly_rho_x1() { return data_[11]; }
+
+  double Ly_rho_x2() const { return data_[12]; }
+  double& Ly_rho_x2() { return data_[12]; }
+
+  double Ly_rho_z1() const { return data_[13]; }
+  double& Ly_rho_z1() { return data_[13]; }
+
+  double Ly_rho_z2() const { return data_[14]; }
+  double& Ly_rho_z2() { return data_[14]; }
+
+  // Expansion terms for the transverse leakage when solving for z
+  double Lz_rho_x1() const { return data_[15]; }
+  double& Lz_rho_x1() { return data_[15]; }
+
+  double Lz_rho_x2() const { return data_[16]; }
+  double& Lz_rho_x2() { return data_[16]; }
+
+  double Lz_rho_y1() const { return data_[17]; }
+  double& Lz_rho_y1() { return data_[17]; }
+
+  double Lz_rho_y2() const { return data_[18]; }
+  double& Lz_rho_y2() { return data_[18]; }
+
+  // Discontinuity factors
+  double adf_xp() const { return data_[19]; }
+  double& adf_xp() { return data_[19]; }
+
+  double adf_xn() const { return data_[20]; }
+  double& adf_xn() { return data_[20]; }
+
+  double adf_yp() const { return data_[21]; }
+  double& adf_yp() { return data_[21]; }
+
+  double adf_yn() const { return data_[22]; }
+  double& adf_yn() { return data_[22]; }
+
+  double adf_zp() const { return data_[23]; }
+  double& adf_zp() { return data_[23]; }
+
+  double adf_zn() const { return data_[24]; }
+  double& adf_zn() { return data_[24]; }
+
+ private:
+  // - The average flux phi
+  // - Must know 6 Net Currents (each node face)
+  // - For each direction, must know transverse leakage coeffs px1, px2, etc
+  //   Must know 12 transverse leakage coefficients
+  // - Must know 6 ADFs, one for each side
+  std::array<double, 25> data_;
+
+  friend class cereal::access;
+  template <class Archive>
+  void serialize(Archive& arc) {
+    arc(CEREAL_NVP(data_));
+  }
+};
+}  // namespace scarabee
+
+#endif

--- a/src/scarabee/_scarabee/nem_diffusion_driver.cpp
+++ b/src/scarabee/_scarabee/nem_diffusion_driver.cpp
@@ -25,6 +25,10 @@ NEMDiffusionDriver::NEMDiffusionDriver(std::shared_ptr<DiffusionGeometry> geom)
     spdlog::error(mssg);
     throw ScarabeeException(mssg);
   }
+
+  spdlog::warn(
+      "NEMDiffusionDriver is deprecated; please use NEM4DiffusionDriver "
+      "instead.");
 }
 
 void NEMDiffusionDriver::set_flux_tolerance(double ftol) {

--- a/src/scarabee/_scarabee/nem_diffusion_driver.cpp
+++ b/src/scarabee/_scarabee/nem_diffusion_driver.cpp
@@ -724,14 +724,14 @@ void NEMDiffusionDriver::update_node_xs_and_matrices() {
       const double fvEf = lc.vEf(g_in) * LRr;
 
       // Update the cross sections
-      xs.D_(g_in) = (fD + 1.) * sa_xs.D(g_in);
-      xs.Ea_(g_in) = (fEa + 1.) * sa_xs.Ea(g_in);
-      xs.Ef_(g_in) = (fEf + 1.) * sa_xs.Ef(g_in);
-      xs.vEf_(g_in) = (fvEf + 1.) * sa_xs.vEf(g_in);
+      xs.D_ref(g_in) = (fD + 1.) * sa_xs.D(g_in);
+      xs.Ea_ref(g_in) = (fEa + 1.) * sa_xs.Ea(g_in);
+      xs.Ef_ref(g_in) = (fEf + 1.) * sa_xs.Ef(g_in);
+      xs.vEf_ref(g_in) = (fvEf + 1.) * sa_xs.vEf(g_in);
 
       for (std::size_t g_out = g_in + 1; g_out < NG_; g_out++) {
         const double fEs = lc.Es(g_in, g_out) * LRr;
-        xs.Es_(g_in, g_out) = (fEs + 1.) * sa_xs.Es(g_in, g_out);
+        xs.Es_ref(g_in, g_out) = (fEs + 1.) * sa_xs.Es(g_in, g_out);
       }
 
       this->fill_node_coupling_matrices(g_in, m, xs, del_x, del_y, del_z);

--- a/src/scarabee/_scarabee/python/nem_diffusion_driver.cpp
+++ b/src/scarabee/_scarabee/python/nem_diffusion_driver.cpp
@@ -13,8 +13,13 @@ void init_NEMDiffusionDriver(py::module& m) {
   py::class_<NEMDiffusionDriver>(
       m, "NEMDiffusionDriver",
       "A NEMDiffusionDriver solves a diffusion problem using the nodal "
-      "expansion method. It is capable of solving 3D problems which are "
-      "defined by providing a :py:class:`DiffusionGeometry` instance.")
+      "expansion method with the response matrix interface current "
+      "formalism. It is capable of solving 3D problems which are "
+      "defined by providing a :py:class:`DiffusionGeometry` instance.\n\n"
+      ".. deprecated:: 0.1.2\n"
+      "   `NEMDiffusionDriver` is deprecated and will be removed in the "
+      "future. It is replaced by `NEM4DiffusionDriver` because the latter "
+      "has better performance.")
 
       .def(py::init<std::shared_ptr<DiffusionGeometry> /*geom*/>(),
            "Initializes a nodal diffusion solver.\n\n"

--- a/src/scarabee/_scarabee/python/nodal_diffusion_driver.cpp
+++ b/src/scarabee/_scarabee/python/nodal_diffusion_driver.cpp
@@ -7,6 +7,8 @@
 #include <diffusion/finite_difference.hpp>
 #include <diffusion/nem4.hpp>
 
+#include <string>
+
 namespace py = pybind11;
 
 using namespace scarabee;
@@ -16,172 +18,194 @@ void init_NodalDiffusionDriver(py::module& m, const char* class_name,
                                const char* description) {
   using NodalSolver = NodalDiffusionDriver<NM>;
 
-  py::class_<NodalSolver>(m, class_name, description)
+  std::string save_doc_str = std::string("Saves the ") + class_name +
+                             std::string(
+                                 " to a binary file.\n\n"
+                                 "Parameters\n"
+                                 "----------\n"
+                                 "fname : str\n"
+                                 "  Name of the file.\n");
 
-      .def(py::init<std::shared_ptr<DiffusionGeometry> /*geom*/>(),
-           "Initializes a nodal diffusion solver.\n\n"
+  std::string load_doc_str = std::string("Loads a previously saved ") +
+                             class_name +
+                             std::string(
+                                 " from a binary file.\n\n"
+                                 "Parameters\n"
+                                 "----------\n"
+                                 "fname : str\n"
+                                 "  Name of the file.\n\n"
+                                 "Returns\n"
+                                 "-------\n") +
+                             class_name;
+
+  auto solver =
+      py::class_<NodalSolver>(m, class_name, description)
+
+          .def(py::init<std::shared_ptr<DiffusionGeometry> /*geom*/>(),
+               "Initializes a nodal diffusion solver.\n\n"
+               "Parameters\n"
+               "----------\n"
+               "geom : DiffusionGeometry\n"
+               "       Problem deffinition to solve.")
+
+          .def("solve", &NodalSolver::solve, "Solves the diffusion problem.")
+
+          .def_property_readonly(
+              "geometry", &NodalSolver::geometry,
+              "The :py:class:`DiffusionGeometry` geometry for the problem.")
+
+          .def_property_readonly("ngroups", &NodalSolver::ngroups,
+                                 "Number of energy groups.")
+
+          .def_property_readonly(
+              "solved", &NodalSolver::solved,
+              "True if the problem has been solved, False otherwise.")
+
+          .def_property_readonly(
+              "keff", &NodalSolver::keff,
+              "Value of keff. This is 1 by default is solved is False.")
+
+          .def_property(
+              "keff_tolerance", &NodalSolver::keff_tolerance,
+              &NodalSolver::set_keff_tolerance,
+              "Maximum relative error in keff for problem convergence.")
+
+          .def_property(
+              "flux_tolerance", &NodalSolver::flux_tolerance,
+              &NodalSolver::set_flux_tolerance,
+              "Maximum relative error in the flux for problem convergence.")
+
+          .def_property("nonlinear_update_frequency",
+                        &NodalSolver::nonlinear_update_frequency,
+                        &NodalSolver::set_nonlinear_update_frequency,
+                        "Frequency at which nonlinear diffusion coefficients "
+                        "are updated.")
+
+          .def_property("source_extrapolation_frequency",
+                        &NodalSolver::source_extrapolation_frequency,
+                        &NodalSolver::set_source_extrapolation_frequency,
+                        "Frequency at which the source is extrapolated to "
+                        "accelerate convergence.")
+
+          .def_property("max_inner_iterations",
+                        &NodalSolver::max_inner_iterations,
+                        &NodalSolver::set_max_inner_iterations,
+                        "Maximum number of inner iteration to perform per "
+                        "outer iteration.");
+
+  if constexpr (NM::update_currents) {
+    solver.def_property(
+        "leakage_corrections", &NodalSolver::leakage_corrections,
+        &NodalSolver::set_leakage_corrections,
+        "Apply leakage corrections to update node cross sections.");
+  }
+
+  solver
+      .def("flux",
+           py::overload_cast<double /*x*/, double /*y*/, double /*z*/,
+                             std::size_t /*g*/>(&NodalSolver::flux, py::const_),
+           "Calculates the flux at the desired position and group. The "
+           "lowest value for any coordinate is 0.\n\n"
            "Parameters\n"
            "----------\n"
-           "geom : DiffusionGeometry\n"
-           "       Problem deffinition to solve.")
+           "x : float\n"
+           "    Position along the x axis.\n"
+           "y : float\n"
+           "    Position along the y axis.\n"
+           "z : float\n"
+           "    Position along the z axis.\n"
+           "g : ing\n"
+           "    Energy group index.\n\n"
+           "Returns\n"
+           "-------\n"
+           "float\n"
+           "      Value of the flux.\n",
+           py::arg("x"), py::arg("y"), py::arg("z"), py::arg("g"))
 
-      .def("solve", &NodalSolver::solve, "Solves the diffusion problem.")
+      .def("flux",
+           py::overload_cast<const xt::xtensor<double, 1>& /*x*/,
+                             const xt::xtensor<double, 1>& /*y*/,
+                             const xt::xtensor<double, 1>& /*z*/>(
+               &NodalSolver::flux, py::const_),
+           "Constructs an array storing the flux at all desired (x,y,z) "
+           "points and at all energy groups. The first index is the group, "
+           "the second is x, the third is y, and the fourth is z.\n\n"
+           "Parameters\n"
+           "----------\n"
+           "x : array of float\n"
+           "    Positions along the x axis.\n"
+           "y : array of float\n"
+           "    Positions along the y axis.\n"
+           "z : array of float\n"
+           "    Positions along the z axis.\n\n"
+           "Returns\n"
+           "-------\n"
+           "array of float\n"
+           "      Value of the flux at all (g,x,y,z).\n",
+           py::arg("x"), py::arg("y"), py::arg("z"))
 
-      .def_property_readonly(
-          "geometry", &NodalSolver::geometry,
-          "The :py:class:`DiffusionGeometry` geometry for the problem.")
+      .def("avg_flux", &NodalSolver::avg_flux,
+           "Constructs an array storing the value of the average flux in "
+           "each node. The resulting array is indexed as (g, x, y, z).\n\n"
+           "Returns\n"
+           "-------\n"
+           "array of float\n"
+           "      Value of the average flux in each node.\n")
 
-      .def_property_readonly("ngroups", &NodalSolver::ngroups,
-                             "Number of energy groups.")
+      .def("power",
+           py::overload_cast<double /*x*/, double /*y*/, double /*z*/>(
+               &NodalSolver::power, py::const_),
+           "Calculates the power density at the desired position. The lowest "
+           "value for any coordinate is 0.\n\n"
+           "Parameters\n"
+           "----------\n"
+           "x : float\n"
+           "    Position along the x axis.\n"
+           "y : float\n"
+           "    Position along the y axis.\n"
+           "z : float\n"
+           "    Position along the z axis.\n\n"
+           "Returns\n"
+           "-------\n"
+           "float\n"
+           "      Value of the power density.\n",
+           py::arg("x"), py::arg("y"), py::arg("z"))
 
-      .def_property_readonly(
-          "solved", &NodalSolver::solved,
-          "True if the problem has been solved, False otherwise.")
+      .def("power",
+           py::overload_cast<const xt::xtensor<double, 1>& /*x*/,
+                             const xt::xtensor<double, 1>& /*y*/,
+                             const xt::xtensor<double, 1>& /*z*/>(
+               &NodalSolver::power, py::const_),
+           "Constructs an array storing the power density at all desired "
+           "(x,y,z) points. The first index is x, the second is y, and the "
+           "third is z.\n\n"
+           "Parameters\n"
+           "----------\n"
+           "x : array of float\n"
+           "    Positions along the x axis.\n"
+           "y : array of float\n"
+           "    Positions along the y axis.\n"
+           "z : array of float\n"
+           "    Positions along the z axis.\n\n"
+           "Returns\n"
+           "-------\n"
+           "array of float\n"
+           "      Value of the power density at all (x,y,z).\n",
+           py::arg("x"), py::arg("y"), py::arg("z"))
 
-      .def_property_readonly(
-          "keff", &NodalSolver::keff,
-          "Value of keff. This is 1 by default is solved is False.")
+      .def("avg_power", &NodalSolver::avg_power,
+           "Constructs an array storing the value of the average power "
+           "density in each node. The resulting array is indexed as "
+           "(x, y, z).\n\n"
+           "Returns\n"
+           "-------\n"
+           "array of float\n"
+           "      Value of the average power density in each node.\n")
 
-      .def_property("keff_tolerance", &NodalSolver::keff_tolerance,
-                    &NodalSolver::set_keff_tolerance,
-                    "Maximum relative error in keff for problem convergence.")
+      .def("save", &NodalSolver::save, save_doc_str.c_str(), py::arg("fname"))
 
-      .def_property(
-          "flux_tolerance", &NodalSolver::flux_tolerance,
-          &NodalSolver::set_flux_tolerance,
-          "Maximum relative error in the flux for problem convergence.")
-
-      .def_property(
-          "nonlinear_update_frequency",
-          &NodalSolver::nonlinear_update_frequency,
-          &NodalSolver::set_nonlinear_update_frequency,
-          "Frequency at which nonlinear diffusion coefficients are updated.")
-
-      .def_property("leakage_corrections", &NodalSolver::leakage_corrections,
-                    &NodalSolver::set_leakage_corrections,
-                    "Apply leakage corrections to update node cross sections.");
-
-  //.def("flux",
-  //     py::overload_cast<double /*x*/, double /*y*/, double /*z*/,
-  //                       std::size_t /*g*/>(&NEMDiffusionDriver::flux,
-  //                                          py::const_),
-  //     "Calculates the flux at the desired position and group. The "
-  //     "lowest value for any coordinate is 0.\n\n"
-  //     "Parameters\n"
-  //     "----------\n"
-  //     "x : float\n"
-  //     "    Position along the x axis.\n"
-  //     "y : float\n"
-  //     "    Position along the y axis.\n"
-  //     "z : float\n"
-  //     "    Position along the z axis.\n"
-  //     "g : ing\n"
-  //     "    Energy group index.\n\n"
-  //     "Returns\n"
-  //     "-------\n"
-  //     "float\n"
-  //     "      Value of the flux.\n",
-  //     py::arg("x"), py::arg("y"), py::arg("z"), py::arg("g"))
-
-  //.def("flux",
-  //     py::overload_cast<const xt::xtensor<double, 1>& /*x*/,
-  //                       const xt::xtensor<double, 1>& /*y*/,
-  //                       const xt::xtensor<double, 1>& /*z*/>(
-  //         &NEMDiffusionDriver::flux, py::const_),
-  //     "Constructs an array storing the flux at all desired (x,y,z) "
-  //     "points and at all energy groups. The first index is the group, "
-  //     "the second is x, the third is y, and the fourth is z.\n\n"
-  //     "Parameters\n"
-  //     "----------\n"
-  //     "x : array of float\n"
-  //     "    Positions along the x axis.\n"
-  //     "y : array of float\n"
-  //     "    Positions along the y axis.\n"
-  //     "z : array of float\n"
-  //     "    Positions along the z axis.\n\n"
-  //     "Returns\n"
-  //     "-------\n"
-  //     "array of float\n"
-  //     "      Value of the flux at all (g,x,y,z).\n",
-  //     py::arg("x"), py::arg("y"), py::arg("z"))
-
-  //.def("avg_flux", &NEMDiffusionDriver::avg_flux,
-  //     "Constructs an array storing the value of the average flux in "
-  //     "each node. The resulting array is indexed as (g, x, y, z).\n\n"
-  //     "Returns\n"
-  //     "-------\n"
-  //     "array of float\n"
-  //     "      Value of the average flux in each node.\n")
-
-  //.def("power",
-  //     py::overload_cast<double /*x*/, double /*y*/, double /*z*/>(
-  //         &NEMDiffusionDriver::power, py::const_),
-  //     "Calculates the power density at the desired position. The lowest "
-  //     "value for any coordinate is 0.\n\n"
-  //     "Parameters\n"
-  //     "----------\n"
-  //     "x : float\n"
-  //     "    Position along the x axis.\n"
-  //     "y : float\n"
-  //     "    Position along the y axis.\n"
-  //     "z : float\n"
-  //     "    Position along the z axis.\n\n"
-  //     "Returns\n"
-  //     "-------\n"
-  //     "float\n"
-  //     "      Value of the power density.\n",
-  //     py::arg("x"), py::arg("y"), py::arg("z"))
-
-  //.def("power",
-  //     py::overload_cast<const xt::xtensor<double, 1>& /*x*/,
-  //                       const xt::xtensor<double, 1>& /*y*/,
-  //                       const xt::xtensor<double, 1>& /*z*/>(
-  //         &NEMDiffusionDriver::power, py::const_),
-  //     "Constructs an array storing the power density at all desired "
-  //     "(x,y,z) points. The first index is x, the second is y, and the "
-  //     "third is z.\n\n"
-  //     "Parameters\n"
-  //     "----------\n"
-  //     "x : array of float\n"
-  //     "    Positions along the x axis.\n"
-  //     "y : array of float\n"
-  //     "    Positions along the y axis.\n"
-  //     "z : array of float\n"
-  //     "    Positions along the z axis.\n\n"
-  //     "Returns\n"
-  //     "-------\n"
-  //     "array of float\n"
-  //     "      Value of the power density at all (x,y,z).\n",
-  //     py::arg("x"), py::arg("y"), py::arg("z"))
-
-  //.def("avg_power", &NEMDiffusionDriver::avg_power,
-  //     "Constructs an array storing the value of the average power "
-  //     "density in each node. The resulting array is indexed as "
-  //     "(x, y, z).\n\n"
-  //     "Returns\n"
-  //     "-------\n"
-  //     "array of float\n"
-  //     "      Value of the average power density in each node.\n")
-
-  //.def("save", &NEMDiffusionDriver::save,
-  //     "Saves the NEMDiffusionDriver to a binary file.\n\n"
-  //     "Parameters\n"
-  //     "----------\n"
-  //     "fname : str\n"
-  //     "  Name of the file.\n",
-  //     py::arg("fname"))
-
-  //.def_static(
-  //    "load", &NEMDiffusionDriver::load,
-  //    "Loads a previously save NEMDiffusionDriver from a binary file.\n\n"
-  //    "Parameters\n"
-  //    "----------\n"
-  //    "fname : str\n"
-  //    "  Name of the file.\n\n"
-  //    "Returns\n"
-  //    "-------\n"
-  //    "NEMDiffusionDriver",
-  //    py::arg("fname"));
+      .def_static("load", &NodalSolver::load, load_doc_str.c_str(),
+                  py::arg("fname"));
 }
 
 void init_all_NodalDiffusionDrivers(py::module& m) {

--- a/src/scarabee/_scarabee/python/nodal_diffusion_driver.cpp
+++ b/src/scarabee/_scarabee/python/nodal_diffusion_driver.cpp
@@ -1,0 +1,201 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include <xtensor-python/pytensor.hpp>
+
+#include <diffusion/nodal_diffusion_driver.hpp>
+#include <diffusion/finite_difference.hpp>
+#include <diffusion/nem4.hpp>
+
+namespace py = pybind11;
+
+using namespace scarabee;
+
+template <NodalMethod NM>
+void init_NodalDiffusionDriver(py::module& m, const char* class_name,
+                               const char* description) {
+  using NodalSolver = NodalDiffusionDriver<NM>;
+
+  py::class_<NodalSolver>(m, class_name, description)
+
+      .def(py::init<std::shared_ptr<DiffusionGeometry> /*geom*/>(),
+           "Initializes a nodal diffusion solver.\n\n"
+           "Parameters\n"
+           "----------\n"
+           "geom : DiffusionGeometry\n"
+           "       Problem deffinition to solve.")
+
+      .def("solve", &NodalSolver::solve, "Solves the diffusion problem.")
+
+      .def_property_readonly(
+          "geometry", &NodalSolver::geometry,
+          "The :py:class:`DiffusionGeometry` geometry for the problem.")
+
+      .def_property_readonly("ngroups", &NodalSolver::ngroups,
+                             "Number of energy groups.")
+
+      .def_property_readonly(
+          "solved", &NodalSolver::solved,
+          "True if the problem has been solved, False otherwise.")
+
+      .def_property_readonly(
+          "keff", &NodalSolver::keff,
+          "Value of keff. This is 1 by default is solved is False.")
+
+      .def_property("keff_tolerance", &NodalSolver::keff_tolerance,
+                    &NodalSolver::set_keff_tolerance,
+                    "Maximum relative error in keff for problem convergence.")
+
+      .def_property(
+          "flux_tolerance", &NodalSolver::flux_tolerance,
+          &NodalSolver::set_flux_tolerance,
+          "Maximum relative error in the flux for problem convergence.")
+
+      .def_property(
+          "nonlinear_update_frequency",
+          &NodalSolver::nonlinear_update_frequency,
+          &NodalSolver::set_nonlinear_update_frequency,
+          "Frequency at which nonlinear diffusion coefficients are updated.")
+
+      .def_property("leakage_corrections", &NodalSolver::leakage_corrections,
+                    &NodalSolver::set_leakage_corrections,
+                    "Apply leakage corrections to update node cross sections.");
+
+  //.def("flux",
+  //     py::overload_cast<double /*x*/, double /*y*/, double /*z*/,
+  //                       std::size_t /*g*/>(&NEMDiffusionDriver::flux,
+  //                                          py::const_),
+  //     "Calculates the flux at the desired position and group. The "
+  //     "lowest value for any coordinate is 0.\n\n"
+  //     "Parameters\n"
+  //     "----------\n"
+  //     "x : float\n"
+  //     "    Position along the x axis.\n"
+  //     "y : float\n"
+  //     "    Position along the y axis.\n"
+  //     "z : float\n"
+  //     "    Position along the z axis.\n"
+  //     "g : ing\n"
+  //     "    Energy group index.\n\n"
+  //     "Returns\n"
+  //     "-------\n"
+  //     "float\n"
+  //     "      Value of the flux.\n",
+  //     py::arg("x"), py::arg("y"), py::arg("z"), py::arg("g"))
+
+  //.def("flux",
+  //     py::overload_cast<const xt::xtensor<double, 1>& /*x*/,
+  //                       const xt::xtensor<double, 1>& /*y*/,
+  //                       const xt::xtensor<double, 1>& /*z*/>(
+  //         &NEMDiffusionDriver::flux, py::const_),
+  //     "Constructs an array storing the flux at all desired (x,y,z) "
+  //     "points and at all energy groups. The first index is the group, "
+  //     "the second is x, the third is y, and the fourth is z.\n\n"
+  //     "Parameters\n"
+  //     "----------\n"
+  //     "x : array of float\n"
+  //     "    Positions along the x axis.\n"
+  //     "y : array of float\n"
+  //     "    Positions along the y axis.\n"
+  //     "z : array of float\n"
+  //     "    Positions along the z axis.\n\n"
+  //     "Returns\n"
+  //     "-------\n"
+  //     "array of float\n"
+  //     "      Value of the flux at all (g,x,y,z).\n",
+  //     py::arg("x"), py::arg("y"), py::arg("z"))
+
+  //.def("avg_flux", &NEMDiffusionDriver::avg_flux,
+  //     "Constructs an array storing the value of the average flux in "
+  //     "each node. The resulting array is indexed as (g, x, y, z).\n\n"
+  //     "Returns\n"
+  //     "-------\n"
+  //     "array of float\n"
+  //     "      Value of the average flux in each node.\n")
+
+  //.def("power",
+  //     py::overload_cast<double /*x*/, double /*y*/, double /*z*/>(
+  //         &NEMDiffusionDriver::power, py::const_),
+  //     "Calculates the power density at the desired position. The lowest "
+  //     "value for any coordinate is 0.\n\n"
+  //     "Parameters\n"
+  //     "----------\n"
+  //     "x : float\n"
+  //     "    Position along the x axis.\n"
+  //     "y : float\n"
+  //     "    Position along the y axis.\n"
+  //     "z : float\n"
+  //     "    Position along the z axis.\n\n"
+  //     "Returns\n"
+  //     "-------\n"
+  //     "float\n"
+  //     "      Value of the power density.\n",
+  //     py::arg("x"), py::arg("y"), py::arg("z"))
+
+  //.def("power",
+  //     py::overload_cast<const xt::xtensor<double, 1>& /*x*/,
+  //                       const xt::xtensor<double, 1>& /*y*/,
+  //                       const xt::xtensor<double, 1>& /*z*/>(
+  //         &NEMDiffusionDriver::power, py::const_),
+  //     "Constructs an array storing the power density at all desired "
+  //     "(x,y,z) points. The first index is x, the second is y, and the "
+  //     "third is z.\n\n"
+  //     "Parameters\n"
+  //     "----------\n"
+  //     "x : array of float\n"
+  //     "    Positions along the x axis.\n"
+  //     "y : array of float\n"
+  //     "    Positions along the y axis.\n"
+  //     "z : array of float\n"
+  //     "    Positions along the z axis.\n\n"
+  //     "Returns\n"
+  //     "-------\n"
+  //     "array of float\n"
+  //     "      Value of the power density at all (x,y,z).\n",
+  //     py::arg("x"), py::arg("y"), py::arg("z"))
+
+  //.def("avg_power", &NEMDiffusionDriver::avg_power,
+  //     "Constructs an array storing the value of the average power "
+  //     "density in each node. The resulting array is indexed as "
+  //     "(x, y, z).\n\n"
+  //     "Returns\n"
+  //     "-------\n"
+  //     "array of float\n"
+  //     "      Value of the average power density in each node.\n")
+
+  //.def("save", &NEMDiffusionDriver::save,
+  //     "Saves the NEMDiffusionDriver to a binary file.\n\n"
+  //     "Parameters\n"
+  //     "----------\n"
+  //     "fname : str\n"
+  //     "  Name of the file.\n",
+  //     py::arg("fname"))
+
+  //.def_static(
+  //    "load", &NEMDiffusionDriver::load,
+  //    "Loads a previously save NEMDiffusionDriver from a binary file.\n\n"
+  //    "Parameters\n"
+  //    "----------\n"
+  //    "fname : str\n"
+  //    "  Name of the file.\n\n"
+  //    "Returns\n"
+  //    "-------\n"
+  //    "NEMDiffusionDriver",
+  //    py::arg("fname"));
+}
+
+void init_all_NodalDiffusionDrivers(py::module& m) {
+  init_NodalDiffusionDriver<FiniteDifference>(
+      m, "FDNodalDiffusionDriver",
+      "A FDNodalDiffusionDriver solves a diffusion problem using the finite "
+      "difference formalism, but inside the nodal solver shell. Therefore, a "
+      "spatial discretization compatible with this method should be used. The "
+      "geometry is defined using a :py:class:`DiffusionGeometry` instance.");
+
+  init_NodalDiffusionDriver<NEM4>(
+      m, "NEM4DiffusionDriver",
+      "Solves a diffusion problem using the 4th order Nodal Expansion Method. "
+      "Uses a standard quadratic transverse leakage approximation. Can be used "
+      "with assembly or half assembly sized nodes. The geometry is defined "
+      "using a :py:class:`DiffusionGeometry` instance.");
+}

--- a/src/scarabee/_scarabee/python/nodal_diffusion_driver.cpp
+++ b/src/scarabee/_scarabee/python/nodal_diffusion_driver.cpp
@@ -212,14 +212,15 @@ void init_all_NodalDiffusionDrivers(py::module& m) {
   init_NodalDiffusionDriver<FiniteDifference>(
       m, "FDNodalDiffusionDriver",
       "A FDNodalDiffusionDriver solves a diffusion problem using the finite "
-      "difference formalism, but inside the nodal solver shell. Therefore, a "
-      "spatial discretization compatible with this method should be used. The "
-      "geometry is defined using a :py:class:`DiffusionGeometry` instance.");
+      "difference formalism, but inside the CMFD nodal solver shell. "
+      "Therefore, a spatial discretization compatible with finite differences "
+      "should be used. The geometry is defined with a "
+      ":py:class:`DiffusionGeometry` instance.");
 
   init_NodalDiffusionDriver<NEM4>(
       m, "NEM4DiffusionDriver",
-      "Solves a diffusion problem using the 4th order Nodal Expansion Method. "
-      "Uses a standard quadratic transverse leakage approximation. Can be used "
-      "with assembly or half assembly sized nodes. The geometry is defined "
-      "using a :py:class:`DiffusionGeometry` instance.");
+      "Solves a diffusion problem using the 4th order Nodal Expansion Method "
+      "with CMFD acceleration. Uses a standard quadratic transverse leakage "
+      "approximation. Can be used with assembly or half assembly sized nodes. "
+      "The geometry is defined with a :py:class:`DiffusionGeometry` instance.");
 }

--- a/src/scarabee/_scarabee/python/scarabee.cpp
+++ b/src/scarabee/_scarabee/python/scarabee.cpp
@@ -49,6 +49,7 @@ extern void init_NEMDiffusionDriver(py::module&);
 extern void init_ReflectorSN(py::module&);
 extern void init_WaterFuncs(py::module&);
 extern void init_DepletionMatrix(py::module&);
+extern void init_all_NodalDiffusionDrivers(py::module&);
 
 PYBIND11_MODULE(_scarabee, m, py::mod_gil_not_used()) {
   xt::import_numpy();
@@ -95,6 +96,7 @@ PYBIND11_MODULE(_scarabee, m, py::mod_gil_not_used()) {
   init_ReflectorSN(m);
   init_WaterFuncs(m);
   init_DepletionMatrix(m);
+  init_all_NodalDiffusionDrivers(m);
 
   m.attr("__author__") = "Hunter Belanger";
   m.attr("__copyright__") =

--- a/src/scarabee/coeur/core_builder.py
+++ b/src/scarabee/coeur/core_builder.py
@@ -1,6 +1,6 @@
 from .core_tile import CoreTile, SimpleTile, QuadrantsTile
 from .core_form_factors import CoreFormFactors
-from .._scarabee import DiffusionGeometry, NEMDiffusionDriver
+from .._scarabee import DiffusionGeometry, NEM4DiffusionDriver
 import numpy as np
 
 
@@ -215,7 +215,7 @@ class CoreBuilder:
             self.zmin_albedo,
             self.zmax_albedo,
         )
-        self.solver = NEMDiffusionDriver(self.diffusion_geometry)
+        self.solver = NEM4DiffusionDriver(self.diffusion_geometry)
 
         # For full core simulations, better to set a flux tolerance of 1.E-6 to
         # avoid asymmetric errors across the core

--- a/src/scarabee/reseau/pwr_assembly.py
+++ b/src/scarabee/reseau/pwr_assembly.py
@@ -2450,7 +2450,7 @@ class PWRAssembly:
             scarabee_log(LogLevel.Info, "")
             scarabee_log(LogLevel.Info, "Kinf: {:.5f}".format(self._asmbly_moc.keff))
 
-        self.apply_leakage_model()
+        self.apply_leakage_model(scilent=self.leakage_corrections)
         self.obtain_flux_spectra()
         self.normalize_flux_to_power()
         self.apply_infinite_spectrum()

--- a/src/scarabee/reseau/reflector.py
+++ b/src/scarabee/reseau/reflector.py
@@ -6,7 +6,7 @@ from .._scarabee import (
     DiffusionData,
     ReflectorSN,
     DiffusionGeometry,
-    NEMDiffusionDriver,
+    NEM4DiffusionDriver,
     FormFactors,
     set_logging_level,
     scarabee_log,
@@ -351,8 +351,10 @@ class Reflector:
             1.0,
             1.0,
         )
-        nem_solver = NEMDiffusionDriver(nem_geom)
-        nem_solver.flux_tolerance = 1.0e-6
+        nem_solver = NEM4DiffusionDriver(nem_geom)
+        nem_solver.nonlinear_update_frequency = 1
+        nem_solver.source_extrapolation_frequency = 100
+        nem_solver.flux_tolerance = 1.0e-7
         set_logging_level(LogLevel.Warning)
         nem_solver.solve()
         set_logging_level(LogLevel.Info)


### PR DESCRIPTION
This PR adds a new nodal solver, `NEM4DiffusionDriver`, which is based on the 2-node CMFD acceleration method. It is therefore approximately 10-20 times faster than the previous `NEMDiffusionDriver` which used the interface current method. While there is a large performance improvement, the new solver architecture will make it very easy to add higher order nodal methods in the future, such as higher order polynomial methods, the Semi-Analytical Nodal Method, and the Analytical Nodal Method.

With this change, the `NEMDiffusionDriver` has been deprecated and will write a warning. The new solver should work as a drop-in replacement, and the new solver is already being used in the rest of the tool chain.

A new finite-difference solver, `FDNodalDiffusionDriver` has also been added, which makes use of the new 2-node CMFD nodal shell. This solver is *not* deprecating the older `FDDiffusionDriver`, however, as that prior solver will still likely give better performance in most cases for finite-difference problems, if you want to use finite-differences for some reason.

This PR closes #27.